### PR TITLE
Persist hide/show toggle across sessions

### DIFF
--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Qwacky",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Qwacky is an open source client for DuckDuckGo Email Protection, To manage and generate @duck.com aliases.",
   "icons": {
     "16": "assets/icons/qwacky-16.png",

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Qwacky",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Qwacky is an open source client for DuckDuckGo Email Protection, To manage and generate @duck.com aliases.",
   "browser_specific_settings": {
     "gecko": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwacky",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { Header } from './components/Header'
 import { theme } from './theme'
 import { useState, useEffect } from 'react'
 
-const APP_VERSION = '1.2.0'
+const APP_VERSION = '1.2.1'
 
 const Container = styled.div`
   width: 360px;

--- a/src/components/AddressListSection.tsx
+++ b/src/components/AddressListSection.tsx
@@ -1,7 +1,10 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import styled from 'styled-components';
 import { MdVisibility, MdVisibilityOff, MdEdit, MdCheck, MdClose, MdDelete, MdDeleteSweep } from "react-icons/md";
 import { ConfirmDialog } from './ConfirmDialog';
+import { StorageService } from '../services/StorageService';
+
+const storageService = new StorageService();
 
 const Section = styled.div`
   margin-bottom: 32px;
@@ -213,7 +216,19 @@ export const AddressListSection: React.FC<AddressListSectionProps> = ({
   }, [onClearAllAddresses]);
 
   const toggleHideAddresses = useCallback(() => {
-    setHideAddresses(prev => !prev);
+    setHideAddresses(prev => {
+      const newState = !prev;
+      storageService.setHideGeneratedAddresses(newState);
+      return newState;
+    });
+  }, []);
+
+  useEffect(() => {
+    const fetchHideAddresses = async () => {
+      const storedHide = await storageService.getHideGeneratedAddresses();
+      setHideAddresses(storedHide);
+    };
+    fetchHideAddresses();
   }, []);
 
   const addressList = useMemo(() => {

--- a/src/components/UserInfoSection.tsx
+++ b/src/components/UserInfoSection.tsx
@@ -1,7 +1,10 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect} from 'react';
 import styled from 'styled-components';
 import { MdVisibility, MdVisibilityOff } from 'react-icons/md';
 import { UserData } from '../types';
+import { StorageService } from '../services/StorageService';
+
+const storageService = new StorageService();
 
 const Section = styled.div`
   margin-bottom: 32px;
@@ -76,11 +79,23 @@ export const UserInfoSection: React.FC<UserInfoSectionProps> = ({
   copyToClipboard 
 }) => {
   const [hideUserInfo, setHideUserInfo] = useState(false);
+  useEffect(() => {
+    const fetchHideUserInfo = async () => {
+      const storedHideUserInfo = await storageService.getHideUserInfo();
+      setHideUserInfo(storedHideUserInfo);
+    };
+
+    fetchHideUserInfo();
+  }, []);
 
   const maskText = (text: string) => "*".repeat(text.length);
 
   const toggleHideUserInfo = useCallback(() => {
-    setHideUserInfo(prev => !prev);
+    setHideUserInfo(prev => {
+      const newState = !prev;
+      storageService.setHideUserInfo(newState);
+      return newState;
+    });
   }, []);
 
   return (

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -180,7 +180,7 @@ export const Login = ({ onSubmit, isAddingAccount, onBack }: LoginProps) => {
       </Button>
       {error && <ErrorMessage>{error}</ErrorMessage>}
       <VersionInfo>
-        Qwacky v1.2.0
+        Qwacky v1.2.1
       </VersionInfo>
     </Container>
   )

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -415,7 +415,7 @@ export const Settings = ({ onBack }: SettingsProps) => {
         ))}
       </Section>
       <VersionInfo>
-        Qwacky v1.2.0
+        Qwacky v1.2.1
       </VersionInfo>
       <NotificationRenderer />
     </Container>

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -245,4 +245,13 @@ export class StorageService {
   async clearStorage(): Promise<void> {
     await chrome.storage.local.clear();
   }
+
+  async getHideUserInfo(): Promise<boolean> {
+    const result = await chrome.storage.local.get('hide_user_info');
+    return result.hide_user_info || false;
+  }
+
+  async setHideUserInfo(hide: boolean): Promise<void> {
+    await chrome.storage.local.set({ hide_user_info: hide });
+  }
 }

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -254,4 +254,13 @@ export class StorageService {
   async setHideUserInfo(hide: boolean): Promise<void> {
     await chrome.storage.local.set({ hide_user_info: hide });
   }
+
+  async getHideGeneratedAddresses(): Promise<boolean> {
+    const result = await chrome.storage.local.get('hide_generated_addresses');
+    return result.hide_generated_addresses || false;
+  }
+
+  async setHideGeneratedAddresses(hide: boolean): Promise<void> {
+    await chrome.storage.local.set({ hide_generated_addresses: hide });
+  }
 }


### PR DESCRIPTION
## Summary

This PR adds persistence for the _hide/show toggle_ in both the **User Info** and **Generated Addresses** sections.

- Added getHideUserInfo / setHideUserInfo to StorageService.
- Added getHideGeneratedAddresses / setHideGeneratedAddresses to StorageService.
- Updated components to restore state from chrome.storage.local on load.
- Toggle actions now update both state and storage, ensuring preferences are remembered across browser sessions.

## Why

Previously, the "hide" button only worked until the extension was closed. This could expose sensitive information when reopening in a public/shared environment.

With this change, the extension now remembers the user’s preference, which significantly improves privacy and creates a consistent experience.

## Thanks 🙏🏻 

Big thanks to @Lanshuns  (and very cool we share the same first name 🥳) for creating and maintaining such an awesome tool.

Resolves #8.