### PR TITLE
Bypass signup extension requirement and Android support

### DIFF
--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -31,6 +31,14 @@
   "host_permissions": [
     "https://quack.duckduckgo.com/*"
   ],
+  "content_scripts": [
+   {
+     "matches": ["https://duckduckgo.com/email/*"],
+     "js": ["bypassExtensionRequirement.js"],
+     "world": "MAIN",
+     "run_at": "document_start"
+   }
+ ],
   "commands": {
     "generate-duck-address": {
       "suggested_key": {

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -7,6 +7,9 @@
     "gecko": {
       "id": "qwacky@local-v1.0.1",
       "strict_min_version": "112.0"
+    },
+    "gecko_android": {
+      "strict_min_version": "112.0"
     }
   },
   "icons": {
@@ -40,6 +43,14 @@
   "host_permissions": [
     "https://quack.duckduckgo.com/*"
   ],
+  "content_scripts": [
+   {
+     "matches": ["https://duckduckgo.com/email/*"],
+     "js": ["bypassExtensionRequirement.js"],
+     "world": "MAIN",
+     "run_at": "document_start"
+   }
+ ],
   "commands": {
     "generate-duck-address": {
       "suggested_key": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useApp } from './context/AppContext'
-import styled, { ThemeProvider } from 'styled-components'
+import styled, { createGlobalStyle, ThemeProvider } from 'styled-components'
 import { Login } from './pages/Login'
 import { OTP } from './pages/OTP'
 import { Dashboard } from './pages/Dashboard'
@@ -11,12 +11,45 @@ import { useState, useEffect } from 'react'
 
 const APP_VERSION = '1.2.1'
 
+const GlobalStyle = createGlobalStyle`
+  * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+      Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    background: ${props => props.theme.background};
+  }
+
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: ${props => props.theme.surface};
+    border-radius: 4px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: ${props => props.theme.border};
+    border-radius: 4px;
+    
+    &:hover {
+      background: ${props => `${props.theme.primary}80`};
+    }
+  }
+`
+
 const Container = styled.div`
   width: 360px;
   min-height: 480px;
-  background: ${props => props.theme.background};
   color: ${props => props.theme.text};
   position: relative;
+  margin: auto; /* Centers it when opened in fullscreen in Firefox for Android */
 `
 
 export const App = () => {
@@ -181,6 +214,7 @@ export const App = () => {
 
   return (
     <ThemeProvider theme={darkMode ? theme.dark : theme.light}>
+      <GlobalStyle />
       <Container>
         <Header 
           onSettingsClick={toggleSettings} 

--- a/src/bypassExtensionRequirement.ts
+++ b/src/bypassExtensionRequirement.ts
@@ -1,0 +1,3 @@
+(navigator as any).duckduckgo ??= {};
+
+export {};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,43 +3,6 @@ import { createRoot } from 'react-dom/client'
 import { App } from './App'
 import { AppProvider } from './context/AppContext'
 import { PermissionProvider } from './context/PermissionContext'
-import { createGlobalStyle, ThemeProvider } from 'styled-components'
-import { theme } from './theme'
-
-const GlobalStyle = createGlobalStyle`
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-
-  body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
-      Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-    width: 360px;
-    min-height: 480px;
-    overflow-x: hidden;
-  }
-
-  ::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-  }
-
-  ::-webkit-scrollbar-track {
-    background: ${props => props.theme.surface};
-    border-radius: 4px;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background: ${props => props.theme.border};
-    border-radius: 4px;
-    
-    &:hover {
-      background: ${props => `${props.theme.primary}80`};
-    }
-  }
-`
 
 const container = document.getElementById('root')
 if (!container) {
@@ -50,10 +13,7 @@ createRoot(container).render(
   <React.StrictMode>
     <AppProvider>
       <PermissionProvider>
-        <ThemeProvider theme={theme.dark}>
-          <GlobalStyle />
-          <App />
-        </ThemeProvider>
+        <App />
       </PermissionProvider>
     </AppProvider>
   </React.StrictMode>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,12 +50,13 @@ export default defineConfig(({ mode }) => {
         input: {
           popup: resolve(__dirname, 'index.html'),
           background: resolve(__dirname, 'src/background.ts'),
-          contentScript: resolve(__dirname, 'src/contentScript.ts')
+          contentScript: resolve(__dirname, 'src/contentScript.ts'),
+          bypassExtensionRequirement: resolve(__dirname, 'src/bypassExtensionRequirement.ts')
         },
         output: {
           format: 'esm',
           entryFileNames: chunk => {
-            if (chunk.name === 'background' || chunk.name === 'contentScript') {
+            if (chunk.name === 'background' || chunk.name === 'contentScript' || chunk.name === 'bypassExtensionRequirement') {
               return '[name].js'
             }
             return 'assets/[name].[hash].js'


### PR DESCRIPTION
Bypass the signup extension requirement to have the DuckDuckGo extension (doesn't collide if installed) and added Firefox for Android support by changing the manifest and centering the extension when opened in fullscreen, also fixed a bug where scrollbars were stuck in dark mode.