### PR TITLE
Add Spanish translation and i18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Qwacky solves this by providing a lightweight, standalone alternative focused en
 - **Stay organized:** notes, tags, search and filtering across all your addresses
 - **Multiple accounts:** manage and switch between duck accounts in one place
 - **Your data, portable:** cross-device sync, plus backup and restore
+- **English and Spanish:** switch languages from Settings, no reinstall needed
 - **And more!**
 
 ## Browser Compatibility
@@ -138,11 +139,35 @@ npm run build:firefox
 
 The built extension will be available in `dist_chrome/` or `dist_firefox/` respectively.
 
-> **Note**: For development and temporary installation in Firefox, you can use `about:debugging` method:
-> 1. Go to `about:debugging`
-> 2. Click "This Firefox" in the left sidebar
-> 3. Click "Load Temporary Add-on"
-> 4. Select the `manifest.json` file from the `dist_firefox/` folder
+## Translations
+
+Qwacky ships with English and Spanish. The language is picked from the
+browser on first run and can be changed under **Settings > Appearance >
+Language**. The choice is saved and applies everywhere, including the
+right-click menu and the on-page notifications.
+
+Everything lives in `src/i18n/`:
+
+```
+src/i18n/
+core.ts             t(), language detection and persistence (no React)
+index.tsx           I18nProvider, useI18n(), <Interpolate>, <RichText>
+locales/en.ts       source of truth, its keys define TranslationKey
+locales/es.ts       typed as Translations, so a missing key fails the build
+```
+
+To add a language:
+
+1. Copy `locales/en.ts` and translate the values. It is typed, so `tsc` will
+   flag anything you miss.
+2. Register it in `core.ts` (`Language`, `LANGUAGES`, `bundles`).
+3. Set `locale.tag` to the BCP 47 tag used for date and number formatting.
+4. Add a `language.<code>` label and a `_locales/<code>/messages.json` for the
+   store listing and the keyboard shortcut descriptions.
+
+Use `t('some.key')` for text, and pass a `count` where a string has `_one` and
+`_other` forms. In JSX, `<Interpolate>` fills a `{placeholder}` with a React
+node and `<RichText>` renders `<b>` markers.
 
 # 💖 Support the Project
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,18 @@
+{
+  "extensionName": {
+    "message": "Qwacky",
+    "description": "Extension name shown in the browser and stores."
+  },
+  "extensionDescription": {
+    "message": "Qwacky is an open source client for DuckDuckGo Email Protection, To manage and generate @duck.com aliases.",
+    "description": "Extension description shown in the browser and stores."
+  },
+  "commandGenerateAddress": {
+    "message": "Generate and fill duck address",
+    "description": "Keyboard shortcut description."
+  },
+  "commandConvertAddress": {
+    "message": "Convert the selected recipient into a send address",
+    "description": "Keyboard shortcut description."
+  }
+}

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,0 +1,18 @@
+{
+  "extensionName": {
+    "message": "Qwacky",
+    "description": "Extension name shown in the browser and stores."
+  },
+  "extensionDescription": {
+    "message": "Qwacky es un cliente de código abierto para DuckDuckGo Email Protection, para gestionar y generar alias @duck.com.",
+    "description": "Extension description shown in the browser and stores."
+  },
+  "commandGenerateAddress": {
+    "message": "Generar y rellenar una dirección duck",
+    "description": "Keyboard shortcut description."
+  },
+  "commandConvertAddress": {
+    "message": "Convertir el destinatario seleccionado en una dirección de envío",
+    "description": "Keyboard shortcut description."
+  }
+}

--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -1,8 +1,9 @@
 {
   "manifest_version": 3,
-  "name": "Qwacky",
+  "name": "__MSG_extensionName__",
+  "default_locale": "en",
   "version": "2.1.0",
-  "description": "Qwacky is an open source client for DuckDuckGo Email Protection, To manage and generate @duck.com aliases.",
+  "description": "__MSG_extensionDescription__",
   "icons": {
     "16": "assets/icons/qwacky-16.png",
     "48": "assets/icons/qwacky-48.png",
@@ -57,13 +58,13 @@
       "suggested_key": {
         "default": "Alt+Shift+Q"
       },
-      "description": "Generate and fill duck address"
+      "description": "__MSG_commandGenerateAddress__"
     },
     "convert-send-address": {
       "suggested_key": {
         "default": "Alt+Shift+S"
       },
-      "description": "Convert the selected recipient into a send address"
+      "description": "__MSG_commandConvertAddress__"
     }
   }
 }

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,8 +1,9 @@
 {
   "manifest_version": 3,
-  "name": "Qwacky",
+  "name": "__MSG_extensionName__",
+  "default_locale": "en",
   "version": "2.1.0",
-  "description": "Qwacky is an open source client for DuckDuckGo Email Protection, To manage and generate @duck.com aliases.",
+  "description": "__MSG_extensionDescription__",
   "browser_specific_settings": {
     "gecko": {
       "id": "qwacky@local-v1.0.1",
@@ -69,13 +70,13 @@
       "suggested_key": {
         "default": "Alt+Shift+Q"
       },
-      "description": "Generate and fill duck address"
+      "description": "__MSG_commandGenerateAddress__"
     },
     "convert-send-address": {
       "suggested_key": {
         "default": "Alt+Shift+S"
       },
-      "description": "Convert the selected recipient into a send address"
+      "description": "__MSG_commandConvertAddress__"
     }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { About } from './pages/About'
 import { MyAccount } from './pages/MyAccount'
 import { Header } from './components/Header'
 import { ConfirmDialog } from './components/ConfirmDialog'
+import { useI18n } from './i18n'
 import { theme } from './theme'
 import { useState, useEffect } from 'react'
 
@@ -81,6 +82,7 @@ const Container = styled.div`
 
 export const App = () => {
   const { darkMode, userData } = useApp()
+  const { t } = useI18n()
   const [currentPage, setCurrentPage] = useState('login')
   const [tempUsername, setTempUsername] = useState('')
   const [showSettings, setShowSettings] = useState(false)
@@ -320,18 +322,18 @@ export const App = () => {
         <ConfirmDialog
           isOpen={autoLoginAccount !== null}
           variant="info"
-          title="Logged in successfully"
-          message={`Automatically logged in as ${autoLoginAccount}@duck.com`}
-          confirmLabel="Got it"
+          title={t('autoLogin.successTitle')}
+          message={t('autoLogin.successMessage', { username: autoLoginAccount ?? '' })}
+          confirmLabel={t('common.gotIt')}
           singleButton
           onConfirm={() => setAutoLoginAccount(null)}
         />
         <ConfirmDialog
           isOpen={autoLoginError !== null}
           variant="warning"
-          title="Auto-login failed"
+          title={t('autoLogin.failedTitle')}
           message={autoLoginError || ''}
-          confirmLabel="OK"
+          confirmLabel={t('common.ok')}
           singleButton
           onConfirm={() => setAutoLoginError(null)}
         />

--- a/src/background.ts
+++ b/src/background.ts
@@ -16,6 +16,7 @@ const api: FirefoxBrowserType = typeof browser !== 'undefined' ? browser : chrom
 import { DuckService } from './services/DuckService'
 import { SyncService } from './services/SyncService'
 import { errorMessage } from './utils/safeOps'
+import { initI18n, t, watchLanguageChanges } from './i18n/core'
 
 const duckService = new DuckService()
 const syncService = new SyncService()
@@ -91,7 +92,7 @@ const ContextMenu = {
       return new Promise<boolean>((resolve) => {
         api.contextMenus.create({
           id: PARENT_MENU_ID,
-          title: 'Qwacky',
+          title: t('contextMenu.parent'),
           contexts: ['editable']
         }, () => {
           const error = chrome.runtime.lastError;
@@ -103,13 +104,13 @@ const ContextMenu = {
           api.contextMenus.create({
             id: CONTEXT_MENU_ID,
             parentId: PARENT_MENU_ID,
-            title: 'Autofill duck address',
+            title: t('contextMenu.generate'),
             contexts: ['editable']
           }, () => { void chrome.runtime.lastError; });
           api.contextMenus.create({
             id: CONVERT_MENU_ID,
             parentId: PARENT_MENU_ID,
-            title: 'Convert to send address',
+            title: t('contextMenu.convert'),
             contexts: ['editable']
           }, () => { void chrome.runtime.lastError; });
           resolve(true);
@@ -203,6 +204,20 @@ api.runtime.onInstalled.addListener(() => {
   setTimeout(initialize, 1000)
 })
 
+void initI18n()
+watchLanguageChanges()
+
+// Menu titles are baked in when the items are created, so rebuild them
+// whenever the user picks a different language.
+api.storage.onChanged.addListener((changes, areaName) => {
+  if (areaName !== 'local' || !changes.language) return
+  void (async () => {
+    if (await FeatureState.get()) {
+      await ContextMenu.create()
+    }
+  })()
+})
+
 setTimeout(initialize, 1000)
 
 api.runtime.onMessage.addListener((message, _sender, sendResponse) => {
@@ -294,7 +309,7 @@ api.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
   if (message.action === 'requestOTP') {
     if (typeof message.username !== 'string') {
-      sendResponse({ status: 'error', message: 'Invalid username' })
+      sendResponse({ status: 'error', message: t('autoLogin.invalidUsername') })
       return true
     }
     duckService.login(message.username)
@@ -305,7 +320,7 @@ api.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
   if (message.action === 'verifyOTP') {
     if (typeof message.username !== 'string' || typeof message.otp !== 'string') {
-      sendResponse({ status: 'error', message: 'Invalid credentials' })
+      sendResponse({ status: 'error', message: t('autoLogin.invalidCredentials') })
       return true
     }
     duckService.verifyOTP(message.username, message.otp)
@@ -316,7 +331,7 @@ api.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
   if (message.action === 'auto-login') {
     if (typeof message.token !== 'string') {
-      sendResponse({ status: 'error', message: 'Invalid token' })
+      sendResponse({ status: 'error', message: t('autoLogin.invalidToken') })
       return true
     }
 
@@ -332,15 +347,15 @@ api.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
         const dashboardResponse = await fetch('https://quack.duckduckgo.com/api/email/dashboard', { headers })
         if (!dashboardResponse.ok) {
-          await api.storage.local.set({ auto_login_error: 'Failed to load dashboard data. Please log in manually.' })
-          sendResponse({ status: 'error', message: 'Failed to load dashboard data.' })
+          await api.storage.local.set({ auto_login_error: t('autoLogin.dashboardFailed') })
+          sendResponse({ status: 'error', message: t('error.dashboardFailed') })
           return
         }
 
         const dashboardData = await dashboardResponse.json()
         if (!dashboardData?.user) {
-          await api.storage.local.set({ auto_login_error: 'Invalid response from server. Please log in manually.' })
-          sendResponse({ status: 'error', message: 'Invalid dashboard data.' })
+          await api.storage.local.set({ auto_login_error: t('autoLogin.invalidResponse') })
+          sendResponse({ status: 'error', message: t('error.dashboardFailed') })
           return
         }
 
@@ -350,8 +365,8 @@ api.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
         const resolvedUsername = dashboardData.user.username || username
         if (!resolvedUsername) {
-          await api.storage.local.set({ auto_login_error: 'Could not determine username. Please log in manually.' })
-          sendResponse({ status: 'error', message: 'Could not determine username.' })
+          await api.storage.local.set({ auto_login_error: t('autoLogin.noUsername') })
+          sendResponse({ status: 'error', message: t('autoLogin.noUsername') })
           return
         }
 
@@ -360,7 +375,7 @@ api.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
         const existing = accounts.find(acc => acc.username === resolvedUsername)
         if (existing && result.currentAccount === resolvedUsername) {
-          sendResponse({ status: 'success', message: 'Already logged in.' })
+          sendResponse({ status: 'success', message: t('autoLogin.alreadyLoggedIn') })
           return
         }
 
@@ -388,7 +403,7 @@ api.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
         sendResponse({ status: 'success' })
       } catch (err) {
-        await api.storage.local.set({ auto_login_error: 'Auto-login failed. Please log in manually.' })
+        await api.storage.local.set({ auto_login_error: t('autoLogin.generic') })
         sendResponse({ status: 'error', message: errorMessage(err) })
       }
     })()
@@ -405,6 +420,24 @@ api.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   return false
 })
 
+/**
+ * The content script is injected as a classic script and cannot import the
+ * locale bundles, so it receives its notification strings from here.
+ */
+const fillMessages = () => ({
+  okCopied: t('notify.filledAndCopied'),
+  okNotCopied: t('notify.filledNotCopied'),
+  failCopied: t('notify.fillFailedCopied'),
+  failNotCopied: t('notify.fillFailedNotCopied')
+})
+
+const convertMessages = () => ({
+  okCopied: t('notify.convertedAndCopied'),
+  okNotCopied: t('notify.convertedNotCopied'),
+  failCopied: t('notify.replaceFailedCopied'),
+  failNotCopied: t('notify.replaceFailedNotCopied')
+})
+
 const performConvert = async (tabId: number, selectionText: string) => {
   try {
     await api.scripting.executeScript({
@@ -419,7 +452,7 @@ const performConvert = async (tabId: number, selectionText: string) => {
       try {
         await api.tabs.sendMessage(tabId, {
           type: 'show-notification',
-          message: 'Select a recipient email to convert'
+          message: t('notify.selectRecipient')
         });
       } catch {
       }
@@ -431,7 +464,7 @@ const performConvert = async (tabId: number, selectionText: string) => {
       try {
         await api.tabs.sendMessage(tabId, {
           type: 'show-notification',
-          message: 'You need to login first'
+          message: t('notify.loginFirst')
         });
       } catch {
       }
@@ -445,7 +478,8 @@ const performConvert = async (tabId: number, selectionText: string) => {
       await api.tabs.sendMessage(tabId, {
         type: 'replace-selection',
         text: alias,
-        find: email
+        find: email,
+        messages: convertMessages()
       });
     } catch {
     }
@@ -472,7 +506,7 @@ if (api.contextMenus) {
           try {
             await api.tabs.sendMessage(tab.id, {
               type: 'show-notification',
-              message: response.message || 'Failed to generate address. Login required?'
+              message: response.message || t('notify.generateFailed')
             });
           } catch {
           }
@@ -487,7 +521,8 @@ if (api.contextMenus) {
         try {
           await api.tabs.sendMessage(tab.id, {
             type: 'fill-address',
-            address: response.address
+            address: response.address,
+            messages: fillMessages()
           });
         } catch {
         }
@@ -547,7 +582,7 @@ if (api.commands) {
         try {
           await api.tabs.sendMessage(activeTab.id, {
             type: 'show-notification',
-            message: response.message || 'Failed to generate address. Login required?'
+            message: response.message || t('notify.generateFailed')
           });
         } catch {
         }
@@ -562,7 +597,8 @@ if (api.commands) {
       try {
         await api.tabs.sendMessage(activeTab.id, {
           type: 'fill-address',
-          address: response.address
+          address: response.address,
+          messages: fillMessages()
         });
       } catch {
       }

--- a/src/components/AddressListSection.tsx
+++ b/src/components/AddressListSection.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { MdVisibility, MdVisibilityOff, MdEdit, MdCheck, MdClose, MdDelete, MdDeleteSweep, MdSearch, MdSort, MdClear, MdLabel, MdExpandMore, MdExpandLess } from "react-icons/md";
 import { ConfirmDialog } from './ConfirmDialog';
 import { SectionHeader } from '../styles/SharedStyles';
+import { Interpolate, TranslationKey, TranslateParams, useI18n } from '../i18n';
 import {
   Section,
   HeaderActions,
@@ -106,7 +107,8 @@ const renderItem = (
   tagInputValue: string,
   setTagInputValue: React.Dispatch<React.SetStateAction<string>>,
   onUpdateTags?: (key: string, tags: string[]) => Promise<void>,
-  allTags?: string[]
+  allTags?: string[],
+  t: (key: TranslationKey, params?: TranslateParams) => string = (key) => key
 ) => {
   const itemTags = item.tags || [];
 
@@ -155,7 +157,7 @@ const renderItem = (
             <TagChip key={tag}>
               {tag}
               {onUpdateTags && (
-                <TagChipRemove onClick={() => handleRemoveTag(tag)} aria-label={`Remove tag ${tag}`}>
+                <TagChipRemove onClick={() => handleRemoveTag(tag)} aria-label={t('list.removeTag', { tag })}>
                   &times;
                 </TagChipRemove>
               )}
@@ -178,13 +180,13 @@ const renderItem = (
                 setTagInputValue('');
               }
             }}
-            placeholder="Add tag..."
+            placeholder={t('list.addTagPlaceholder')}
             autoFocus
           />
-          <IconButton onClick={() => { handleAddTag(tagInputValue); }} aria-label="Add tag">
+          <IconButton onClick={() => { handleAddTag(tagInputValue); }} aria-label={t('list.addTag')}>
             <MdCheck size={16} />
           </IconButton>
-          <IconButton onClick={() => { setEditingTags(null); setTagInputValue(''); }} aria-label="Close tag input">
+          <IconButton onClick={() => { setEditingTags(null); setTagInputValue(''); }} aria-label={t('list.closeTagInput')}>
             <MdClose size={16} />
           </IconButton>
           {suggestions.length > 0 && (
@@ -209,15 +211,15 @@ const renderItem = (
               if (e.key === 'Enter') { e.preventDefault(); handleSaveNotes(); }
               else if (e.key === 'Escape') { e.preventDefault(); handleCancelEdit(); }
             }}
-            placeholder="Add notes..."
-            aria-label="Edit notes"
+            placeholder={t('list.notesPlaceholder')}
+            aria-label={t('list.editNotes')}
             autoFocus={editing.autoFocus}
           />
           <NotesActions>
-            <IconButton onClick={handleSaveNotes} aria-label="Save notes">
+            <IconButton onClick={handleSaveNotes} aria-label={t('list.saveNotes')}>
               <MdCheck size={18} />
             </IconButton>
-            <IconButton onClick={handleCancelEdit} aria-label="Cancel editing">
+            <IconButton onClick={handleCancelEdit} aria-label={t('list.cancelEditing')}>
               <MdClose size={18} />
             </IconButton>
           </NotesActions>
@@ -232,15 +234,15 @@ const renderItem = (
                   setEditingTags(editingTags === item.key ? null : item.key);
                   setTagInputValue('');
                 }}
-                aria-label="Edit tags"
+                aria-label={t('list.editTags')}
               >
                 <MdLabel size={18} />
               </IconButton>
             )}
-            <IconButton onClick={() => handleEditNotes(item)} aria-label="Edit notes">
+            <IconButton onClick={() => handleEditNotes(item)} aria-label={t('list.editNotes')}>
               <MdEdit size={18} />
             </IconButton>
-            <IconButton className="delete" onClick={() => setDeleteConfirm(item.key)} aria-label="Delete">
+            <IconButton className="delete" onClick={() => setDeleteConfirm(item.key)} aria-label={t('common.delete')}>
               <MdDelete size={18} />
             </IconButton>
           </ButtonsContainer>
@@ -275,6 +277,7 @@ export const ItemListSection: React.FC<ItemListSectionProps> = ({
   const [editingTags, setEditingTags] = useState<string | null>(null);
   const [tagInputValue, setTagInputValue] = useState('');
   const notesInputRef = React.useRef<HTMLInputElement>(null);
+  const { t } = useI18n();
 
   useEffect(() => {
     if (autoEditKey) {
@@ -391,10 +394,10 @@ export const ItemListSection: React.FC<ItemListSectionProps> = ({
       result.push({ name: tag, items: groups.get(tag)! });
     });
     if (untagged.length > 0) {
-      result.push({ name: 'Untagged', items: untagged });
+      result.push({ name: t('list.untagged'), items: untagged });
     }
     return result;
-  }, [filteredAndSorted, groupByTag]);
+  }, [filteredAndSorted, groupByTag, t]);
 
   const cycleSortOrder = useCallback(() => {
     setSortOrder(current => current === 'newest' ? 'oldest' : 'newest');
@@ -412,7 +415,7 @@ export const ItemListSection: React.FC<ItemListSectionProps> = ({
     });
   }, []);
 
-  const getSortLabel = () => sortOrder === 'newest' ? 'Newest' : 'Oldest';
+  const getSortLabel = () => sortOrder === 'newest' ? t('list.sortNewest') : t('list.sortOldest');
 
   const renderItemCallback = useCallback((item: ListItem, index: number) => {
     return renderItem(
@@ -421,9 +424,9 @@ export const ItemListSection: React.FC<ItemListSectionProps> = ({
       handleEditNotes, handleSaveNotes, handleCancelEdit,
       setDeleteConfirm,
       editingTags, setEditingTags, tagInputValue, setTagInputValue,
-      onUpdateTags, allTags
+      onUpdateTags, allTags, t
     );
-  }, [copyToClipboard, formatTime, editing, handleEditNotes, handleSaveNotes, handleCancelEdit, editingTags, tagInputValue, onUpdateTags, allTags]);
+  }, [copyToClipboard, formatTime, editing, handleEditNotes, handleSaveNotes, handleCancelEdit, editingTags, tagInputValue, onUpdateTags, allTags, t]);
 
   const itemList = useMemo(() => {
     if (items.length === 0) {
@@ -440,8 +443,8 @@ export const ItemListSection: React.FC<ItemListSectionProps> = ({
       return (
         <EmptyState>
           <MdSearch />
-          <h3>No results found</h3>
-          <p>Try adjusting your search or filter</p>
+          <h3>{t('list.noResultsTitle')}</h3>
+          <p>{t('list.noResultsSubtitle')}</p>
         </EmptyState>
       );
     }
@@ -468,7 +471,7 @@ export const ItemListSection: React.FC<ItemListSectionProps> = ({
         {filteredAndSorted.map((item, index) => renderItemCallback(item, index))}
       </AddressList>
     );
-  }, [filteredAndSorted, groupedItems, groupByTag, hidden, config, collapsedGroups, toggleGroup, renderItemCallback, items.length]);
+  }, [filteredAndSorted, groupedItems, groupByTag, hidden, config, collapsedGroups, toggleGroup, renderItemCallback, items.length, t]);
 
   return (
     <>
@@ -477,11 +480,11 @@ export const ItemListSection: React.FC<ItemListSectionProps> = ({
           <h2>{config.title}</h2>
           <HeaderActions>
             {items.length > 0 && (
-              <IconButton className="clear" onClick={() => setShowClearConfirm(true)} aria-label={`Clear all ${config.itemsLabel}`}>
+              <IconButton className="clear" onClick={() => setShowClearConfirm(true)} aria-label={t('list.clearAllItems', { items: config.itemsLabel })}>
                 <MdDeleteSweep size={24} />
               </IconButton>
             )}
-            <IconButton onClick={toggleHidden} aria-label={hidden ? `Show ${config.itemsLabel}` : `Hide ${config.itemsLabel}`} aria-expanded={!hidden}>
+            <IconButton onClick={toggleHidden} aria-label={hidden ? t('list.showItems', { items: config.itemsLabel }) : t('list.hideItems', { items: config.itemsLabel })} aria-expanded={!hidden}>
               {hidden ? <MdVisibility /> : <MdVisibilityOff />}
             </IconButton>
           </HeaderActions>
@@ -497,22 +500,22 @@ export const ItemListSection: React.FC<ItemListSectionProps> = ({
                   placeholder={config.searchPlaceholder}
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
-                  aria-label={`Search ${config.itemsLabel}`}
+                  aria-label={t('list.searchItems', { items: config.itemsLabel })}
                 />
                 {searchQuery && (
-                  <ClearSearchButton onClick={() => setSearchQuery('')} aria-label="Clear search">
+                  <ClearSearchButton onClick={() => setSearchQuery('')} aria-label={t('list.clearSearch')}>
                     <MdClear size={20} />
                   </ClearSearchButton>
                 )}
               </SearchInputWrapper>
-              <SortButton onClick={cycleSortOrder} active={sortOrder !== 'newest'} aria-label={`Sort by ${getSortLabel()}`}>
+              <SortButton onClick={cycleSortOrder} active={sortOrder !== 'newest'} aria-label={t('list.sortBy', { order: getSortLabel() })}>
                 <MdSort />
                 {getSortLabel()}
               </SortButton>
               {uniqueTags.length > 0 && (
-                <GroupByButton onClick={() => setGroupByTag(prev => !prev)} active={groupByTag} aria-label="Group by tag">
+                <GroupByButton onClick={() => setGroupByTag(prev => !prev)} active={groupByTag} aria-label={t('list.groupByTag')}>
                   <MdLabel />
-                  Group
+                  {t('list.group')}
                 </GroupByButton>
               )}
             </SearchContainer>
@@ -520,7 +523,7 @@ export const ItemListSection: React.FC<ItemListSectionProps> = ({
             {uniqueTags.length > 0 && (
               <TagFilterRow>
                 <TagFilterChip active={activeTagFilter === null} onClick={() => setActiveTagFilter(null)}>
-                  All
+                  {t('list.filterAll')}
                 </TagFilterChip>
                 {uniqueTags.map(tag => (
                   <TagFilterChip key={tag} active={activeTagFilter === tag} onClick={() => setActiveTagFilter(activeTagFilter === tag ? null : tag)}>
@@ -528,7 +531,7 @@ export const ItemListSection: React.FC<ItemListSectionProps> = ({
                   </TagFilterChip>
                 ))}
                 <TagFilterChip active={activeTagFilter === '__untagged__'} onClick={() => setActiveTagFilter(activeTagFilter === '__untagged__' ? null : '__untagged__')}>
-                  Untagged
+                  {t('list.untagged')}
                 </TagFilterChip>
               </TagFilterRow>
             )}
@@ -536,7 +539,10 @@ export const ItemListSection: React.FC<ItemListSectionProps> = ({
             {(searchQuery || activeTagFilter) && (
               <SearchInfo>
                 <span>
-                  Showing <ResultCount>{filteredAndSorted.length}</ResultCount> of {items.length} {config.itemsLabel}
+                  <Interpolate
+                    text={t('list.showingCount', { total: items.length, items: config.itemsLabel })}
+                    values={{ shown: <ResultCount>{filteredAndSorted.length}</ResultCount> }}
+                  />
                 </span>
               </SearchInfo>
             )}
@@ -550,8 +556,8 @@ export const ItemListSection: React.FC<ItemListSectionProps> = ({
         isOpen={deleteConfirm !== null}
         title={config.deleteTitle}
         message={deleteConfirm ? config.getDeleteMessage(deleteConfirm) : ''}
-        confirmLabel="Delete"
-        cancelLabel="Cancel"
+        confirmLabel={t('common.delete')}
+        cancelLabel={t('common.cancel')}
         onConfirm={handleDeleteConfirm}
         onCancel={() => setDeleteConfirm(null)}
       />
@@ -560,8 +566,8 @@ export const ItemListSection: React.FC<ItemListSectionProps> = ({
         isOpen={showClearConfirm}
         title={config.clearTitle}
         message={config.clearMessage}
-        confirmLabel="Clear all"
-        cancelLabel="Cancel"
+        confirmLabel={t('list.clearAll')}
+        cancelLabel={t('common.cancel')}
         onConfirm={handleClearConfirm}
         onCancel={() => setShowClearConfirm(false)}
       />

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,5 +1,6 @@
 import { MdWarning, MdInfo } from 'react-icons/md';
 import { ReactNode } from 'react';
+import { useI18n } from '../i18n';
 import {
   DialogOverlay,
   Dialog,
@@ -25,17 +26,21 @@ interface ConfirmDialogProps {
 export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   title,
   message,
-  confirmLabel = 'Confirm',
-  cancelLabel = 'Cancel',
+  confirmLabel,
+  cancelLabel,
   onConfirm,
   onCancel,
   isOpen,
   singleButton = false,
   variant = 'warning'
 }) => {
+  const { t } = useI18n();
+
   if (!isOpen) return null;
 
   const Icon = variant === 'info' ? MdInfo : MdWarning;
+  const confirmText = confirmLabel ?? t('common.confirm');
+  const cancelText = cancelLabel ?? t('common.cancel');
 
   return (
     <DialogOverlay onClick={(e) => {
@@ -55,14 +60,14 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
               onClick={onCancel}
               variant="primary"
             >
-              {cancelLabel}
+              {cancelText}
             </DialogButton>
           )}
           <DialogButton
             onClick={onConfirm}
             singleButton={singleButton}
           >
-            {confirmLabel}
+            {confirmText}
           </DialogButton>
         </DialogButtonContainer>
       </Dialog>

--- a/src/components/DashboardTabs.tsx
+++ b/src/components/DashboardTabs.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { MdAdd, MdSend } from 'react-icons/md';
+import { useI18n } from '../i18n';
 import { TabsContainer, Tab } from '../styles/DashboardTabs.styles';
 
 interface DashboardTabsProps {
@@ -8,6 +9,8 @@ interface DashboardTabsProps {
 }
 
 export const DashboardTabs: React.FC<DashboardTabsProps> = ({ activeTab, onTabChange }) => {
+  const { t } = useI18n();
+
   return (
     <TabsContainer role="tablist">
       <Tab
@@ -16,7 +19,7 @@ export const DashboardTabs: React.FC<DashboardTabsProps> = ({ activeTab, onTabCh
         aria-selected={activeTab === 'generate'}
         role="tab"
       >
-        <MdAdd /> Generate
+        <MdAdd /> {t('dashboard.tabGenerate')}
       </Tab>
       <Tab
         active={activeTab === 'send'}
@@ -24,7 +27,7 @@ export const DashboardTabs: React.FC<DashboardTabsProps> = ({ activeTab, onTabCh
         aria-selected={activeTab === 'send'}
         role="tab"
       >
-        <MdSend /> Send
+        <MdSend /> {t('dashboard.tabSend')}
       </Tab>
     </TabsContainer>
   );

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import { t } from '../i18n/core'
 
 const ErrorContainer = styled.div`
   display: flex;
@@ -50,10 +51,10 @@ export class ErrorBoundary extends React.Component<{ children: React.ReactNode }
     if (this.state.hasError) {
       return (
         <ErrorContainer>
-          <ErrorTitle>Something went wrong</ErrorTitle>
-          <ErrorMessage>The extension encountered an unexpected error.</ErrorMessage>
+          <ErrorTitle>{t('errorBoundary.title')}</ErrorTitle>
+          <ErrorMessage>{t('errorBoundary.message')}</ErrorMessage>
           <ReloadButton onClick={() => window.location.reload()}>
-            Reload Extension
+            {t('errorBoundary.reload')}
           </ReloadButton>
         </ErrorContainer>
       )

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import { MdLogout, MdSettings, MdMenu, MdAccountCircle, MdPersonAdd, MdNewReleases, MdSwapHoriz, MdKeyboardArrowDown, MdEdit, MdCheck, MdClose, MdFavorite, MdInfoOutline, MdManageAccounts, MdOpenInNew } from 'react-icons/md'
 import { useApp } from '../context/AppContext'
 import { ConfirmDialog } from './ConfirmDialog'
+import { RichText, useI18n } from '../i18n'
 import {
   HeaderContainer,
   TitleSection,
@@ -36,6 +37,7 @@ interface HeaderProps {
 
 export const Header = ({ onSettingsClick, onAddAccountClick, onChangelogClick, onAboutClick, onMyAccountClick }: HeaderProps) => {
   const { userData, logout, accounts, currentAccount, switchAccount } = useApp()
+  const { t } = useI18n()
   const [menuDropdownOpen, setMenuDropdownOpen] = useState(false)
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false)
   const [accountsListOpen, setAccountsListOpen] = useState(false)
@@ -140,16 +142,16 @@ export const Header = ({ onSettingsClick, onAddAccountClick, onChangelogClick, o
           <Title>Qwacky</Title>
         </TitleSection>
         <IconsSection>
-          <IconButton onClick={openSupport}>
+          <IconButton onClick={openSupport} aria-label={t('header.support')} title={t('header.support')}>
             <MdFavorite size={24} />
           </IconButton>
           {!isPopout && (
-            <IconButton onClick={handlePopout}>
+            <IconButton onClick={handlePopout} aria-label={t('header.openInWindow')} title={t('header.openInWindow')}>
               <MdOpenInNew size={24} />
             </IconButton>
           )}
           <MenuDropdown ref={menuDropdownRef}>
-            <IconButton onClick={() => setMenuDropdownOpen(!menuDropdownOpen)}>
+            <IconButton onClick={() => setMenuDropdownOpen(!menuDropdownOpen)} aria-label={t('header.menu')}>
               <MdMenu size={24} />
             </IconButton>
             <DropdownContent isOpen={menuDropdownOpen}>
@@ -169,7 +171,7 @@ export const Header = ({ onSettingsClick, onAddAccountClick, onChangelogClick, o
                     <AccountsMenuWrapper isOpen={accountsListOpen}>
                       <DropdownItem onClick={() => setAccountsListOpen(!accountsListOpen)}>
                         <MdSwapHoriz size={20} />
-                        Switch account
+                        {t('header.switchAccount')}
                         <MdKeyboardArrowDown
                           size={20}
                           style={{
@@ -198,33 +200,33 @@ export const Header = ({ onSettingsClick, onAddAccountClick, onChangelogClick, o
                   {accountsListOpen && <DropdownDivider />}
                   <DropdownItem onClick={() => handleMenuItemClick(onAddAccountClick)}>
                     <MdPersonAdd size={20} />
-                    Add account
+                    {t('header.addAccount')}
                   </DropdownItem>
                   <DropdownItem onClick={() => handleMenuItemClick(onMyAccountClick)}>
                     <MdManageAccounts size={20} />
-                    My account
+                    {t('header.myAccount')}
                   </DropdownItem>
                   <DropdownDivider />
                 </>
               )}
               <DropdownItem onClick={() => handleMenuItemClick(onSettingsClick)}>
                 <MdSettings size={20} />
-                Settings
+                {t('header.settings')}
               </DropdownItem>
               <DropdownItem onClick={() => handleMenuItemClick(onChangelogClick)}>
                 <MdNewReleases size={20} />
-                What's new?
+                {t('header.whatsNew')}
               </DropdownItem>
               <DropdownItem onClick={() => handleMenuItemClick(onAboutClick)}>
                 <MdInfoOutline size={20} />
-                About
+                {t('header.about')}
               </DropdownItem>
               {userData && (
                 <>
                   <DropdownDivider />
                   <DropdownItem onClick={handleLogoutClick} logout>
                     <MdLogout size={20} />
-                    Log out
+                    {t('header.logout')}
                   </DropdownItem>
                 </>
               )}
@@ -235,10 +237,10 @@ export const Header = ({ onSettingsClick, onAddAccountClick, onChangelogClick, o
 
       <ConfirmDialog
         isOpen={showLogoutConfirm}
-        title="Confirm logout"
-        message="Are you sure you want to log out?"
-        confirmLabel="Log out"
-        cancelLabel="Cancel"
+        title={t('header.logoutConfirmTitle')}
+        message={t('header.logoutConfirmMessage')}
+        confirmLabel={t('header.logout')}
+        cancelLabel={t('common.cancel')}
         onConfirm={handleLogoutConfirm}
         onCancel={() => setShowLogoutConfirm(false)}
       />
@@ -246,13 +248,13 @@ export const Header = ({ onSettingsClick, onAddAccountClick, onChangelogClick, o
       {showNicknameDialog && (
         <NicknameEditDialog onClick={() => setShowNicknameDialog(false)}>
           <NicknameDialogContent onClick={(e) => e.stopPropagation()}>
-            <NicknameDialogTitle>Edit account nickname</NicknameDialogTitle>
+            <NicknameDialogTitle>{t('header.nicknameTitle')}</NicknameDialogTitle>
             <NicknameDialogSubtitle>
-              Set a custom nickname for <strong>{currentAccount}</strong>
+              <RichText text={t('header.nicknameSubtitle', { username: `<b>${currentAccount}</b>` })} />
             </NicknameDialogSubtitle>
             <NicknameInput
               type="text"
-              placeholder="Enter nickname (optional)"
+              placeholder={t('header.nicknamePlaceholder')}
               value={nickname}
               onChange={(e) => setNickname(e.target.value)}
               onKeyDown={(e) => {
@@ -265,15 +267,15 @@ export const Header = ({ onSettingsClick, onAddAccountClick, onChangelogClick, o
               {currentAccount && accountNicknames[currentAccount] && (
                 <NicknameButton onClick={handleClearNickname}>
                   <MdClose size={18} />
-                  Clear
+                  {t('common.clear')}
                 </NicknameButton>
               )}
               <NicknameButton onClick={() => setShowNicknameDialog(false)}>
-                Cancel
+                {t('common.cancel')}
               </NicknameButton>
               <NicknameButton primary onClick={handleSaveNickname}>
                 <MdCheck size={18} />
-                Save
+                {t('common.save')}
               </NicknameButton>
             </NicknameDialogActions>
           </NicknameDialogContent>

--- a/src/components/PermissionToggle.tsx
+++ b/src/components/PermissionToggle.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react'
 import { usePermissions, PERMISSIONS } from '../context/PermissionContext'
+import { useI18n } from '../i18n'
 import { ConfirmDialog } from './ConfirmDialog'
 import Markdown from 'react-markdown'
 import {
@@ -28,20 +29,18 @@ const isFirefox = navigator.userAgent.toLowerCase().includes('firefox')
 const CHROME_PERMISSION_NOTICE_SEEN = 'chromePermissionNoticeSeen'
 
 interface PermissionToggleProps {
-  name: string
-  description: string
+  permission: keyof typeof PERMISSIONS
   isEnabled: boolean
   onChange: (enabled: boolean) => void
   disabled?: boolean
 }
-
 export const PermissionToggle: React.FC<PermissionToggleProps> = ({
-  name,
-  description,
+  permission,
   isEnabled,
   onChange,
   disabled = false
 }) => {
+  const { t } = useI18n()
   const [status, setStatus] = useState<{ message: string; type: 'info' | 'error' | 'success' } | null>(null)
   const [showPermissionsNotice, setShowPermissionsNotice] = useState(false)
   const [showChromeNotice, setShowChromeNotice] = useState(false)
@@ -51,17 +50,15 @@ export const PermissionToggle: React.FC<PermissionToggleProps> = ({
   const tooltipTimeoutRef = useRef<number | null>(null);
   const reloadTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const permissionType = Object.entries(PERMISSIONS).find(
-    ([_, permission]) => permission.name === name
-  )?.[0] as keyof typeof PERMISSIONS | undefined;
+  const definition = PERMISSIONS[permission];
+  const name = t(definition.nameKey);
+  const description = t(definition.descriptionKey);
+  const isRequired = definition.isRequired;
 
-  const isRequired = permissionType ? PERMISSIONS[permissionType]?.isRequired : false;
-
-  const browserSpecificInfo = permissionType && PERMISSIONS[permissionType]?.browserSpecificInfo
-    ? isFirefox
-      ? PERMISSIONS[permissionType].browserSpecificInfo?.firefox
-      : PERMISSIONS[permissionType].browserSpecificInfo?.chrome
-    : undefined;
+  const browserSpecificInfoKey = isFirefox
+    ? definition.browserSpecificInfoKey?.firefox
+    : definition.browserSpecificInfoKey?.chrome;
+  const browserSpecificInfo = browserSpecificInfoKey ? t(browserSpecificInfoKey) : undefined;
 
   const showTooltip = () => {
     if (tooltipTimeoutRef.current) {
@@ -146,7 +143,7 @@ export const PermissionToggle: React.FC<PermissionToggleProps> = ({
             }
             const granted = await requestPermissions('contextMenuFeatures')
             if (!granted) {
-              setStatus({ message: 'Permission request was denied', type: 'error' })
+              setStatus({ message: t('permissionToggle.denied'), type: 'error' })
               onChange(false)
               return
             }
@@ -157,7 +154,7 @@ export const PermissionToggle: React.FC<PermissionToggleProps> = ({
           enabled: true
         })
         if (response?.success) {
-          setStatus({ message: 'Reloading to apply changes...', type: 'success' })
+          setStatus({ message: t('permissionToggle.reloading'), type: 'success' })
           onChange(true)
 
           if (reloadTimeoutRef.current) clearTimeout(reloadTimeoutRef.current)
@@ -165,17 +162,17 @@ export const PermissionToggle: React.FC<PermissionToggleProps> = ({
             api.runtime.sendMessage({ action: 'reload-extension' })
           }, 1500)
         } else {
-          setStatus({ message: 'Failed to enable feature', type: 'error' })
+          setStatus({ message: t('permissionToggle.enableFailed'), type: 'error' })
           onChange(false)
         }
       } else {
-        setStatus({ message: `Disabling ${name}...`, type: 'info' })
+        setStatus({ message: t('permissionToggle.disabling', { name }), type: 'info' })
         const response = await api.runtime.sendMessage({
           action: 'toggleFeature',
           enabled: false
         })
         if (response?.success) {
-          setStatus({ message: 'Reloading to apply changes...', type: 'success' })
+          setStatus({ message: t('permissionToggle.reloading'), type: 'success' })
           await removePermissions('contextMenuFeatures')
           onChange(false)
 
@@ -184,48 +181,47 @@ export const PermissionToggle: React.FC<PermissionToggleProps> = ({
             api.runtime.sendMessage({ action: 'reload-extension' })
           }, 1500)
         } else {
-          setStatus({ message: 'Failed to disable feature', type: 'error' })
+          setStatus({ message: t('permissionToggle.disableFailed'), type: 'error' })
           onChange(true)
         }
       }
     } catch (error) {
       console.error('Toggle error:', error)
-      setStatus({ message: 'An error occurred', type: 'error' })
+      setStatus({ message: t('permissionToggle.error'), type: 'error' })
       onChange(!newState)
     }
-  }, [name, disabled, onChange, removePermissions, checkPermission, requestPermissions, chromeNoticeSeen, isRequired])
+  }, [name, disabled, onChange, removePermissions, checkPermission, requestPermissions, chromeNoticeSeen, isRequired, t])
 
   const FirefoxPermissionNotice = () => (
     <NoticeContainer>
-      <NoticeParagraph>To enable this feature:</NoticeParagraph>
-      <NoticeParagraph>1. Firefox will show a permissions request - click 'Allow'</NoticeParagraph>
-      <NoticeParagraph>2. Return to the extension and toggle the feature again</NoticeParagraph>
-      <NoticeParagraph>You can disable this feature anytime later.</NoticeParagraph>
+      <NoticeParagraph>{t('permissionToggle.firefox1')}</NoticeParagraph>
+      <NoticeParagraph>{t('permissionToggle.firefox2')}</NoticeParagraph>
+      <NoticeParagraph>{t('permissionToggle.firefox3')}</NoticeParagraph>
+      <NoticeParagraph>{t('permissionToggle.firefox4')}</NoticeParagraph>
     </NoticeContainer>
   );
 
   const ChromePermissionNotice = () => (
     <NoticeContainer>
-      <NoticeParagraph>Chrome handles permissions differently than Firefox.</NoticeParagraph>
-      <NoticeParagraph>To enable this feature, Chrome will show a permission request once. After clicking 'Done', a permissions dialog may appear.</NoticeParagraph>
-      <NoticeParagraph>If you see a permissions dialog, click 'Allow' then return to the extension and toggle the feature again.</NoticeParagraph>
-      <NoticeParagraph>For more details, see: <LinkText
+      <NoticeParagraph>{t('permissionToggle.chrome1')}</NoticeParagraph>
+      <NoticeParagraph>{t('permissionToggle.chrome2')}</NoticeParagraph>
+      <NoticeParagraph>{t('permissionToggle.chrome3')}</NoticeParagraph>
+      <NoticeParagraph>{t('permissionToggle.chrome4')}{' '}<LinkText
           href="https://github.com/Lanshuns/Qwacky?tab=readme-ov-file#browser-specific-permission-handling-and-limitations"
           target="_blank"
           rel="noopener noreferrer"
         >
-          Browser-Specific Permission Handling and Limitations
+          {t('permissionToggle.chromeLink')}
         </LinkText>
       </NoticeParagraph>
     </NoticeContainer>
   );
-
   return (
     <ToggleContainer disabled={disabled && !isRequired}>
       <ToggleHeader>
         <ToggleTitle>
           {name}
-          {!isFirefox && name === "Autofill" && (
+          {!isFirefox && permission === 'contextMenuFeatures' && (
             <InfoIconContainer
               onMouseEnter={showTooltip}
               onMouseLeave={hideTooltip}
@@ -240,13 +236,13 @@ export const PermissionToggle: React.FC<PermissionToggleProps> = ({
                 onMouseEnter={showTooltip}
                 onMouseLeave={hideTooltip}
               >
-                Browser additional permissions request will only appear once if not already granted.{' '}
+                {t('permissionToggle.tooltip')}{' '}
                 <LinkText
                   href="https://github.com/Lanshuns/Qwacky?tab=readme-ov-file#browser-specific-permission-handling-and-limitations"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Read More
+                  {t('permissionToggle.readMore')}
                 </LinkText>
               </Tooltip>
             </InfoIconContainer>
@@ -279,18 +275,18 @@ export const PermissionToggle: React.FC<PermissionToggleProps> = ({
       )}
       <ConfirmDialog
         isOpen={showPermissionsNotice}
-        title="Permissions notice"
+        title={t('permissionToggle.noticeTitle')}
         message={<FirefoxPermissionNotice />}
-        confirmLabel="Done"
+        confirmLabel={t('common.done')}
         onConfirm={handleNoticeDone}
         singleButton={true}
         variant="info"
       />
       <ConfirmDialog
         isOpen={showChromeNotice}
-        title="Permissions notice"
+        title={t('permissionToggle.noticeTitle')}
         message={<ChromePermissionNotice />}
-        confirmLabel="Done"
+        confirmLabel={t('common.done')}
         onConfirm={handleChromeNoticeDone}
         singleButton={true}
         variant="info"

--- a/src/components/UserInfoSection.tsx
+++ b/src/components/UserInfoSection.tsx
@@ -3,6 +3,7 @@ import { MdVisibility, MdVisibilityOff } from 'react-icons/md';
 import { UserData } from '../types';
 import { StorageService } from '../services/StorageService';
 import { SectionHeader } from '../styles/SharedStyles';
+import { useI18n } from '../i18n';
 import { UserInfoCard, InfoItem, UserInfoIconButton } from '../styles/ui.styles';
 
 const storageService = new StorageService();
@@ -18,6 +19,7 @@ export const UserInfoSection: React.FC<UserInfoSectionProps> = ({
   addressesCount,
   copyToClipboard
 }) => {
+  const { t } = useI18n();
   const [hideUserInfo, setHideUserInfo] = useState(false);
   useEffect(() => {
     const fetchHideUserInfo = async () => {
@@ -39,10 +41,10 @@ export const UserInfoSection: React.FC<UserInfoSectionProps> = ({
   return (
     <UserInfoCard>
       <SectionHeader style={hideUserInfo ? { marginBottom: 0 } : undefined}>
-        <h2 id="user-info-heading">My account</h2>
+        <h2 id="user-info-heading">{t('userInfo.title')}</h2>
         <UserInfoIconButton
           onClick={toggleHideUserInfo}
-          aria-label={hideUserInfo ? "Show user information" : "Hide user information"}
+          aria-label={hideUserInfo ? t('userInfo.show') : t('userInfo.hide')}
           aria-expanded={!hideUserInfo}
           aria-controls="user-info-content"
         >
@@ -52,7 +54,7 @@ export const UserInfoSection: React.FC<UserInfoSectionProps> = ({
       {!hideUserInfo && (
         <div id="user-info-content" aria-labelledby="user-info-heading">
           <InfoItem>
-            <label className="highlight" id="username-label">Duck username</label>
+            <label className="highlight" id="username-label">{t('userInfo.username')}</label>
             <div
               onClick={(e) => copyToClipboard(`${userData.user.username}@duck.com`, e.nativeEvent)}
               role="button"
@@ -69,7 +71,7 @@ export const UserInfoSection: React.FC<UserInfoSectionProps> = ({
             </div>
           </InfoItem>
           <InfoItem>
-            <label className="highlight" id="email-label">Forwarding email</label>
+            <label className="highlight" id="email-label">{t('userInfo.email')}</label>
             <div
               onClick={(e) => copyToClipboard(userData.user.email, e.nativeEvent)}
               role="button"
@@ -86,14 +88,14 @@ export const UserInfoSection: React.FC<UserInfoSectionProps> = ({
             </div>
           </InfoItem>
           <InfoItem>
-            <label className="highlight" id="count-label">Total generated</label>
+            <label className="highlight" id="count-label">{t('userInfo.totalGenerated')}</label>
             <div aria-labelledby="count-label">
               <span>{addressesCount}</span>
             </div>
           </InfoItem>
           {userData.invites.length > 0 && (
             <InfoItem>
-              <label id="invites-label">Invites</label>
+              <label id="invites-label">{t('userInfo.invites')}</label>
               <div aria-labelledby="invites-label">
                 <span>{userData.invites.length}</span>
               </div>

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -2,6 +2,20 @@ type BrowserType = typeof chrome;
 declare const browser: BrowserType;
 const api: BrowserType = typeof browser !== 'undefined' ? browser : chrome;
 
+/** Notification strings, already translated by the background page. */
+interface ResultMessages {
+  okCopied: string
+  okNotCopied: string
+  failCopied: string
+  failNotCopied: string
+}
+
+const pickMessage = (messages: ResultMessages | undefined, ok: boolean, copied: boolean): string => {
+  if (!messages) return ''
+  if (ok) return copied ? messages.okCopied : messages.okNotCopied
+  return copied ? messages.failCopied : messages.failNotCopied
+}
+
 const setupConnection = () => {
   try {
     api.runtime.connect();
@@ -29,7 +43,7 @@ const showNotification = (message: string) => {
   Object.assign(notification.style, styles)
   notification.setAttribute('role', 'status')
   notification.setAttribute('aria-live', 'polite')
-  notification.textContent = message === 'Not authenticated' ? 'You need to login first' : message
+  notification.textContent = message
   document.body.appendChild(notification)
   
   setTimeout(() => {
@@ -115,30 +129,14 @@ if (!(window as unknown as { __qwackyContentScript?: boolean }).__qwackyContentS
 
       const copied = await copyToClipboard(`${message.address}@duck.com`);
 
-      if (!filled) {
-        showNotification(copied
-          ? 'Could not fill input, address copied to clipboard'
-          : 'Could not fill input or copy to clipboard. Please check permissions in settings.');
-      } else {
-        showNotification(copied
-          ? 'Address filled and copied to clipboard'
-          : 'Address filled but could not copy to clipboard. Please check permissions in settings.');
-      }
+      showNotification(pickMessage(message.messages, filled, copied));
     }
 
     if (message.type === 'replace-selection') {
       const replaced = replaceSelection(message.text, message.find)
       const copied = await copyToClipboard(message.text)
 
-      if (!replaced) {
-        showNotification(copied
-          ? 'Could not replace selection, address copied to clipboard'
-          : 'Could not replace selection or copy to clipboard. Please check permissions in settings.');
-      } else {
-        showNotification(copied
-          ? 'Converted and copied to clipboard'
-          : 'Converted, but could not copy to clipboard. Please check permissions in settings.');
-      }
+      showNotification(pickMessage(message.messages, replaced, copied));
     }
 
     if (message.type === 'show-notification') {

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -3,6 +3,7 @@ import { DuckService } from '../services/DuckService'
 import { SyncService } from '../services/SyncService'
 import { UserData } from '../types'
 import { ConfirmDialog } from '../components/ConfirmDialog'
+import { useI18n } from '../i18n'
 
 export type ThemeMode = 'light' | 'dark' | 'system';
 
@@ -32,6 +33,7 @@ const duckService = new DuckService()
 const syncService = new SyncService()
 
 export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children }: { children: React.ReactNode }) => {
+  const { t } = useI18n()
   const [themeMode, setThemeMode] = useState<ThemeMode>(() => {
     try {
       const saved = localStorage.getItem('themeMode')
@@ -299,7 +301,7 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
 
   const deleteCurrentAccount = async () => {
     if (!currentAccount) {
-      return { status: 'error' as const, message: 'No account is currently selected' }
+      return { status: 'error' as const, message: t('myAccount.noAccountSelected') }
     }
 
     const result = await duckService.deleteAccount(currentAccount)
@@ -341,10 +343,13 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       <ConfirmDialog
         isOpen={syncSessionPrompt !== null}
         variant="info"
-        title="Synced accounts found"
-        message={syncSessionPrompt ? `Found ${syncSessionPrompt.newAccounts.length} synced account(s): ${syncSessionPrompt.newAccounts.map(u => u + '@duck.com').join(', ')}. Would you like to restore them?` : ''}
-        confirmLabel="Restore"
-        cancelLabel="Cancel"
+        title={t('sync.foundTitle')}
+        message={syncSessionPrompt ? t('sync.foundMessage', {
+          count: syncSessionPrompt.newAccounts.length,
+          accounts: syncSessionPrompt.newAccounts.map(u => u + '@duck.com').join(', ')
+        }) : ''}
+        confirmLabel={t('sync.restore')}
+        cancelLabel={t('common.cancel')}
         onConfirm={handleRestoreSyncSession}
         onCancel={() => setSyncSessionPrompt(null)}
       />

--- a/src/context/PermissionContext.tsx
+++ b/src/context/PermissionContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react'
+import { TranslationKey } from '../i18n/core'
 
 interface ExtendedPermissionEvent extends chrome.events.Event<() => void> {
   addListener: (callback: () => void) => void;
@@ -25,34 +26,39 @@ const isFirefox = navigator.userAgent.toLowerCase().includes('firefox')
 type PermissionType = 'storage' | 'contextMenuFeatures' | 'contextMenu'
 
 interface Permission {
-  name: string
-  description: string
+  /** Stable identifier — never shown to the user. */
+  id: PermissionType
+  nameKey: TranslationKey
+  descriptionKey: TranslationKey
   isRequired: boolean
   permissions: string[]
-  browserSpecificInfo?: {
-    firefox?: string
-    chrome?: string
+  browserSpecificInfoKey?: {
+    firefox?: TranslationKey
+    chrome?: TranslationKey
   }
 }
 
 export const PERMISSIONS: Record<PermissionType, Permission> = {
   storage: {
-    name: 'Storage',
-    description: '`storage`\nRequired for the extension to function properly, to store and retrieve data locally',
+    id: 'storage',
+    nameKey: 'permission.storage.name',
+    descriptionKey: 'permission.storage.description',
     isRequired: true,
     permissions: ['storage']
   },
   contextMenu: {
-    name: 'Context menu',
-    description: '`contextMenus`\nFirefox requires this permission to be listed in the manifest\'s permissions block at install time, [Read More](https://github.com/Lanshuns/Qwacky?tab=readme-ov-file#browser-specific-permission-handling-and-limitations)',
+    id: 'contextMenu',
+    nameKey: 'permission.contextMenu.name',
+    descriptionKey: 'permission.contextMenu.description',
     isRequired: true,
     permissions: ['contextMenus']
   },
   contextMenuFeatures: {
-    name: 'Autofill',
-    description: isFirefox
-      ? '`activeTab`, `clipboardWrite` and `scripting`\nEnables the Qwacky options in the context menu, to generate a duck address or convert a recipient into a send address'
-      : '`contextMenus`, `activeTab`, `clipboardWrite` and `scripting`\nEnables the Qwacky options in the context menu, to generate a duck address or convert a recipient into a send address',
+    id: 'contextMenuFeatures',
+    nameKey: 'permission.autofill.name',
+    descriptionKey: isFirefox
+      ? 'permission.autofill.descriptionFirefox'
+      : 'permission.autofill.descriptionChrome',
     isRequired: false,
     permissions: [
       'activeTab',
@@ -61,7 +67,6 @@ export const PERMISSIONS: Record<PermissionType, Permission> = {
     ]
   }
 }
-
 interface PermissionContextType {
   checkPermission: (permission: PermissionType) => Promise<boolean>
   requestPermissions: (type: PermissionType) => Promise<boolean>

--- a/src/i18n/core.ts
+++ b/src/i18n/core.ts
@@ -1,0 +1,171 @@
+import { en, TranslationKey, Translations } from './locales/en'
+import { es } from './locales/es'
+
+export type { TranslationKey, Translations }
+
+export type Language = 'en' | 'es'
+
+export const LANGUAGES: Language[] = ['en', 'es']
+
+export const STORAGE_KEY = 'language'
+
+const bundles: Record<Language, Translations> = { en, es }
+
+export const isLanguage = (value: unknown): value is Language =>
+  typeof value === 'string' && (LANGUAGES as string[]).includes(value)
+
+export const detectLanguage = (): Language => {
+  const candidates = [
+    ...(typeof navigator !== 'undefined' && Array.isArray(navigator.languages)
+      ? navigator.languages
+      : []),
+    typeof navigator !== 'undefined' ? navigator.language : ''
+  ]
+
+  for (const candidate of candidates) {
+    const base = String(candidate || '').toLowerCase().split('-')[0]
+    if (isLanguage(base)) return base
+  }
+
+  return 'en'
+}
+
+const readStoredLanguage = (): Language | null => {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (isLanguage(saved)) return saved
+  } catch {}
+  return null
+}
+
+let currentLanguage: Language = readStoredLanguage() ?? detectLanguage()
+
+const listeners = new Set<(language: Language) => void>()
+
+export const getLanguage = (): Language => currentLanguage
+
+export const subscribe = (listener: (language: Language) => void): (() => void) => {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+const applyLanguage = (language: Language) => {
+  if (language === currentLanguage) return
+  currentLanguage = language
+  try {
+    document.documentElement.lang = language
+  } catch {}
+  listeners.forEach(listener => listener(language))
+}
+
+export interface TranslateParams {
+  [key: string]: string | number | undefined
+  count?: number
+}
+
+const interpolate = (template: string, params?: TranslateParams): string => {
+  if (!params) return template
+  return template.replace(/\{(\w+)\}/g, (match, name: string) => {
+    const value = params[name]
+    return value === undefined ? match : String(value)
+  })
+}
+
+/**
+ * Translate a key for the current language.
+ *
+ * When `params.count` is present, `<key>_one` / `<key>_other` variants are
+ * preferred over the bare key, so callers get the right plural form.
+ */
+export const translate = (
+  key: TranslationKey,
+  params?: TranslateParams,
+  language: Language = currentLanguage
+): string => {
+  const bundle = bundles[language] || en
+
+  let template: string | undefined
+  if (params && typeof params.count === 'number') {
+    const variant = `${key}_${params.count === 1 ? 'one' : 'other'}` as TranslationKey
+    template = bundle[variant] ?? en[variant]
+  }
+
+  template = template ?? bundle[key] ?? en[key]
+
+  if (template === undefined) {
+    return key
+  }
+
+  return interpolate(template, params)
+}
+
+export const t = translate
+
+/** BCP 47 tag used for Intl date/number formatting. */
+export const getLocaleTag = (language: Language = currentLanguage): string =>
+  translate('locale.tag', undefined, language)
+
+/**
+ * Load the persisted language (if any) and keep this context in sync with
+ * changes made from other extension pages.
+ */
+export const initI18n = async (): Promise<Language> => {
+  try {
+    const result = await chrome.storage.local.get(STORAGE_KEY)
+    if (isLanguage(result?.[STORAGE_KEY])) {
+      applyLanguage(result[STORAGE_KEY])
+      try {
+        localStorage.setItem(STORAGE_KEY, result[STORAGE_KEY])
+      } catch {}
+    } else {
+      await chrome.storage.local.set({ [STORAGE_KEY]: currentLanguage })
+    }
+  } catch {}
+
+  try {
+    document.documentElement.lang = currentLanguage
+  } catch {}
+
+  return currentLanguage
+}
+
+export const watchLanguageChanges = (): (() => void) => {
+  const handleChange = (
+    changes: { [key: string]: chrome.storage.StorageChange },
+    areaName: string
+  ) => {
+    if (areaName !== 'local') return
+    const next = changes[STORAGE_KEY]?.newValue
+    if (isLanguage(next)) {
+      try {
+        localStorage.setItem(STORAGE_KEY, next)
+      } catch {}
+      applyLanguage(next)
+    }
+  }
+
+  try {
+    chrome.storage.onChanged.addListener(handleChange)
+  } catch {
+    return () => {}
+  }
+
+  return () => {
+    try {
+      chrome.storage.onChanged.removeListener(handleChange)
+    } catch {}
+  }
+}
+
+export const setLanguage = async (language: Language): Promise<void> => {
+  if (!isLanguage(language)) return
+  try {
+    localStorage.setItem(STORAGE_KEY, language)
+  } catch {}
+  applyLanguage(language)
+  try {
+    await chrome.storage.local.set({ [STORAGE_KEY]: language })
+  } catch {}
+}

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -1,0 +1,107 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import {
+  getLanguage,
+  getLocaleTag,
+  initI18n,
+  Language,
+  LANGUAGES,
+  setLanguage as persistLanguage,
+  subscribe,
+  translate,
+  TranslateParams,
+  TranslationKey,
+  watchLanguageChanges
+} from './core'
+
+export * from './core'
+
+type TranslateFn = (key: TranslationKey, params?: TranslateParams) => string
+
+interface I18nContextType {
+  language: Language
+  languages: Language[]
+  setLanguage: (language: Language) => void
+  localeTag: string
+  t: TranslateFn
+}
+
+const I18nContext = createContext<I18nContextType | undefined>(undefined)
+
+export const I18nProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [language, setLanguageState] = useState<Language>(getLanguage)
+
+  useEffect(() => {
+    const unsubscribe = subscribe(setLanguageState)
+    const unwatch = watchLanguageChanges()
+    initI18n().then(setLanguageState)
+    return () => {
+      unsubscribe()
+      unwatch()
+    }
+  }, [])
+
+  const t = useCallback<TranslateFn>(
+    (key, params) => translate(key, params, language),
+    [language]
+  )
+
+  const setLanguage = useCallback((next: Language) => {
+    void persistLanguage(next)
+  }, [])
+
+  const value = useMemo<I18nContextType>(
+    () => ({
+      language,
+      languages: LANGUAGES,
+      setLanguage,
+      localeTag: getLocaleTag(language),
+      t
+    }),
+    [language, setLanguage, t]
+  )
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>
+}
+
+export const useI18n = (): I18nContextType => {
+  const context = useContext(I18nContext)
+  if (context === undefined) {
+    throw new Error('useI18n must be used within an I18nProvider')
+  }
+  return context
+}
+
+/**
+ * Renders a translated string, swapping its `{placeholder}` slots for React
+ * nodes. Use it when a value needs its own markup — plain string values should
+ * go through `t(key, params)` instead.
+ */
+export const Interpolate: React.FC<{
+  text: string
+  values: Record<string, React.ReactNode>
+}> = ({ text, values }) => (
+  <>
+    {text.split(/(\{\w+\})/g).map((part, index) => {
+      const match = part.match(/^\{(\w+)\}$/)
+      return (
+        <React.Fragment key={index}>
+          {match && match[1] in values ? values[match[1]] : part}
+        </React.Fragment>
+      )
+    })}
+  </>
+)
+
+/**
+ * Renders a translated string that contains `<b>…</b>` emphasis markers as
+ * real elements. Only `<b>` is recognised — everything else stays literal
+ * text, so translations can never inject markup.
+ */
+export const RichText: React.FC<{ text: string }> = ({ text }) => (
+  <>
+    {text.split(/(<b>.*?<\/b>)/g).map((part, index) => {
+      const match = part.match(/^<b>(.*?)<\/b>$/)
+      return match ? <strong key={index}>{match[1]}</strong> : <React.Fragment key={index}>{part}</React.Fragment>
+    })}
+  </>
+)

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1,0 +1,417 @@
+export const en = {
+  // Language / locale
+  'locale.tag': 'en-US',
+  'language.en': 'English',
+  'language.es': 'Español',
+
+  // Shared
+  'common.cancel': 'Cancel',
+  'common.confirm': 'Confirm',
+  'common.save': 'Save',
+  'common.clear': 'Clear',
+  'common.close': 'Close',
+  'common.delete': 'Delete',
+  'common.done': 'Done',
+  'common.ok': 'OK',
+  'common.gotIt': 'Got it',
+  'common.back': 'Back',
+  'common.backToDashboard': 'Back to Dashboard',
+  'common.copied': 'Copied!',
+  'common.failedToCopy': 'Failed to copy',
+  'common.current': '(current)',
+  'common.unknownError': 'Unknown error',
+
+  // Header
+  'header.switchAccount': 'Switch account',
+  'header.addAccount': 'Add account',
+  'header.myAccount': 'My account',
+  'header.settings': 'Settings',
+  'header.whatsNew': "What's new?",
+  'header.about': 'About',
+  'header.logout': 'Log out',
+  'header.logoutConfirmTitle': 'Confirm logout',
+  'header.logoutConfirmMessage': 'Are you sure you want to log out?',
+  'header.nicknameTitle': 'Edit account nickname',
+  'header.nicknameSubtitle': 'Set a custom nickname for {username}',
+  'header.nicknamePlaceholder': 'Enter nickname (optional)',
+  'header.support': 'Support the project',
+  'header.openInWindow': 'Open in a new window',
+  'header.menu': 'Menu',
+
+  // Login
+  'login.message': 'Login to manage your {duck} addresses',
+  'login.placeholder': 'Enter duck username',
+  'login.sending': 'Sending...',
+  'login.continue': 'Continue',
+  'login.alreadyLoggedIn': 'This account is already logged in',
+  'login.noAccount': "Don't have one?",
+  'login.createNow': 'Create now',
+  'login.signupTitle': 'Create a duck address',
+  'login.signupMessage':
+    "You'll be redirected to DuckDuckGo to create your @duck.com address. Once you complete the signup, you'll be automatically logged in.",
+  'login.signupConfirm': 'Continue to DuckDuckGo',
+
+  // Auto-login (from signup)
+  'autoLogin.successTitle': 'Logged in successfully',
+  'autoLogin.successMessage': 'Automatically logged in as {username}@duck.com',
+  'autoLogin.failedTitle': 'Auto-login failed',
+  'autoLogin.dashboardFailed': 'Failed to load dashboard data. Please log in manually.',
+  'autoLogin.invalidResponse': 'Invalid response from server. Please log in manually.',
+  'autoLogin.noUsername': 'Could not determine username. Please log in manually.',
+  'autoLogin.generic': 'Auto-login failed. Please log in manually.',
+  'autoLogin.alreadyLoggedIn': 'Already logged in.',
+  'autoLogin.invalidToken': 'Invalid token',
+  'autoLogin.invalidUsername': 'Invalid username',
+  'autoLogin.invalidCredentials': 'Invalid credentials',
+
+  // OTP
+  'otp.backToLogin': 'Back to login',
+  'otp.loggedInAs': 'Logged in as {username}@duck.com',
+  'otp.message': 'One-time passphrase sent to your email',
+  'otp.placeholder': 'e.g. morality landless proved paprika',
+  'otp.verifying': 'Verifying...',
+  'otp.verify': 'Verify OTP',
+  'otp.resend': 'Resend passphrase',
+  'otp.resendSuccess': 'A new passphrase has been sent to your email.',
+  'otp.resendFailed': 'Failed to resend passphrase.',
+  'otp.switchFailed': 'Failed to switch to new account',
+  'otp.userDataFailed': 'Failed to get user data',
+  'otp.verifyFailed': 'Failed to verify OTP',
+  'otp.genericError': 'An error occurred. Please try again.',
+  'otp.troubleToggle': 'Having trouble logging in?',
+  'otp.hint':
+    "Didn't receive it? Check your spam or junk folder. Some email providers (like ProtonMail) may delay or filter messages from DuckDuckGo.",
+
+  // Dashboard
+  'dashboard.tabGenerate': 'Generate',
+  'dashboard.tabSend': 'Send',
+  'dashboard.generating': 'Generating...',
+  'dashboard.generate': 'Generate new address',
+  'dashboard.loadFailed': 'Failed to load data',
+  'dashboard.generateFailed': 'Failed to generate address',
+  'dashboard.hideInstructions': 'Hide',
+  'dashboard.howToUse': 'How to use',
+  'dashboard.step1': "Enter recipient's email & click <b>Convert</b>",
+  'dashboard.step2': 'Paste the result as <b>To</b> in your email client',
+  'dashboard.step3': 'Send from the email linked to your DDG account',
+  'dashboard.learnMore': 'Learn more',
+  'dashboard.from': 'From:',
+  'dashboard.recipientPlaceholder': 'someone@email.com',
+  'dashboard.convert': 'Convert',
+  'dashboard.sendFrom': 'Send from',
+  'dashboard.closePicker': 'Close picker',
+  'dashboard.searchAddresses': 'Search addresses...',
+  'dashboard.personalAddress': 'Personal address',
+
+  // Generated address list
+  'list.generated.title': 'Generated addresses',
+  'list.generated.itemsLabel': 'addresses',
+  'list.generated.emptyTitle': 'No addresses yet',
+  'list.generated.emptySubtitle': 'Click the button above to generate your first address',
+  'list.generated.searchPlaceholder': 'Search addresses or notes...',
+  'list.generated.deleteTitle': 'Delete address',
+  'list.generated.deleteMessage': 'Are you sure you want to delete this address\n({key}@duck.com)?',
+  'list.generated.clearTitle': 'Clear all addresses',
+  'list.generated.clearMessage':
+    'Are you sure you want to clear all addresses?\n\nThis action cannot be undone.',
+
+  // Reverse alias list
+  'list.send.title': 'History',
+  'list.send.itemsLabel': 'aliases',
+  'list.send.emptyTitle': 'No history yet',
+  'list.send.emptySubtitle': 'Convert a recipient email above to get started',
+  'list.send.searchPlaceholder': 'Search emails or notes...',
+  'list.send.deleteTitle': 'Delete reverse alias',
+  'list.send.deleteMessage': 'Are you sure you want to delete the reverse alias for\n{key}?',
+  'list.send.clearTitle': 'Clear all history',
+  'list.send.clearMessage':
+    'Are you sure you want to clear all reverse alias history?\n\nThis action cannot be undone.',
+
+  // List UI (shared by both lists)
+  'list.copyItem': 'Copy {value}',
+  'list.copyReverseAlias': 'Copy reverse alias for {value}',
+  'list.removeTag': 'Remove tag {tag}',
+  'list.addTagPlaceholder': 'Add tag...',
+  'list.addTag': 'Add tag',
+  'list.closeTagInput': 'Close tag input',
+  'list.notesPlaceholder': 'Add notes...',
+  'list.editNotes': 'Edit notes',
+  'list.saveNotes': 'Save notes',
+  'list.cancelEditing': 'Cancel editing',
+  'list.editTags': 'Edit tags',
+  'list.untagged': 'Untagged',
+  'list.sortNewest': 'Newest',
+  'list.sortOldest': 'Oldest',
+  'list.sortBy': 'Sort by {order}',
+  'list.noResultsTitle': 'No results found',
+  'list.noResultsSubtitle': 'Try adjusting your search or filter',
+  'list.clearAllItems': 'Clear all {items}',
+  'list.showItems': 'Show {items}',
+  'list.hideItems': 'Hide {items}',
+  'list.searchItems': 'Search {items}',
+  'list.clearSearch': 'Clear search',
+  'list.groupByTag': 'Group by tag',
+  'list.group': 'Group',
+  'list.filterAll': 'All',
+  'list.showingCount': 'Showing {shown} of {total} {items}',
+  'list.clearAll': 'Clear all',
+
+  // User info card
+  'userInfo.title': 'My account',
+  'userInfo.show': 'Show user information',
+  'userInfo.hide': 'Hide user information',
+  'userInfo.username': 'Duck username',
+  'userInfo.email': 'Forwarding email',
+  'userInfo.totalGenerated': 'Total generated',
+  'userInfo.invites': 'Invites',
+
+  // My account page
+  'myAccount.manage': 'Manage your duck account',
+  'myAccount.removing': 'Removing...',
+  'myAccount.remove': 'Remove account local data',
+  'myAccount.removeTitle': 'Remove account local data',
+  'myAccount.removeMessage':
+    "You're about to remove {account} along with its {data} from this device and from sync. Your DuckDuckGo account itself is not affected. This cannot be undone.",
+  'myAccount.thisAccount': 'this account',
+  'myAccount.savedAddresses': '{count} saved addresses',
+  'myAccount.savedAddresses_one': '{count} saved address',
+  'myAccount.savedAddresses_other': '{count} saved addresses',
+  'myAccount.reverseAliases': '{count} reverse aliases',
+  'myAccount.reverseAliases_one': '{count} reverse alias',
+  'myAccount.reverseAliases_other': '{count} reverse aliases',
+  'myAccount.addressesAndAliases': '{addresses} and {aliases}',
+  'myAccount.removeFailed': 'Failed to remove account',
+  'myAccount.noAccountSelected': 'No account is currently selected',
+
+  // About page
+  'about.support': 'Support the project',
+  'about.github': 'GitHub repository',
+  'about.firefoxStore': 'Firefox add-ons',
+  'about.chromeStore': 'Chrome web store',
+
+  // Changelog page
+  'changelog.loading': 'Loading changelog...',
+  'changelog.error': 'Could not load changelog. Please try again later.',
+  'changelog.loadFailed': 'Failed to load changelog',
+  'changelog.heading': "What's new?",
+
+  // Settings — appearance
+  'settings.appearance': 'Appearance',
+  'settings.theme': 'Theme',
+  'settings.themeLight': 'Light',
+  'settings.themeDark': 'Dark',
+  'settings.themeSystem': 'System',
+  'settings.language': 'Language',
+  'settings.timeFormat24h': '24-hour time',
+
+  // Settings — permissions
+  'settings.permissions': 'Permissions & features',
+
+  // Settings — sync
+  'settings.sync': 'Sync',
+  'settings.syncOptions': 'Sync options',
+  'settings.syncAddresses': 'Addresses',
+  'settings.syncReverseAliases': 'Reverse Aliases',
+  'settings.syncSessionData': 'Session Data',
+  'settings.syncSessionHint': '(login data & settings)',
+  'settings.syncTokenWarningFirefox':
+    'Session data includes your access tokens. They are encrypted by Firefox during sync but stored in your Mozilla account.',
+  'settings.syncTokenWarningChrome':
+    'Session data includes your access tokens. They are encrypted by Chrome during sync but stored in your Google account.',
+  'settings.syncStatus': 'Status:',
+  'settings.syncLastSynced': 'Last synced {date}',
+  'settings.syncNever': 'Never synced',
+  'settings.syncRefresh': 'Refresh',
+  'settings.syncStorageUsed': 'Storage used:',
+  'settings.syncAutoDisabled': 'Sync was automatically disabled because storage quota was exceeded.',
+  'settings.allAccounts': 'All accounts',
+  'settings.selectAccounts': 'Select accounts...',
+  'settings.accountsSelected': '{count} accounts selected',
+
+  // Settings — backup & restore
+  'settings.backup': 'Backup & restore',
+  'settings.exporting': 'Exporting...',
+  'settings.exportBackup': 'Export backup',
+  'settings.importing': 'Importing...',
+  'settings.importBackup': 'Import backup',
+  'settings.importHint':
+    'Import accepts a Qwacky backup (.json), or a plain .txt list of existing duck.com addresses — one per line.',
+  'settings.exportOptions': 'Export options',
+  'settings.includeSession': 'Include session',
+  'settings.exportFailed': 'Failed to export backup',
+  'settings.importFailedInvalidFile': 'Import failed, invalid file',
+  'settings.importFailed': 'Import failed',
+  'settings.importFailedWithReason': 'Import failed: {reason}',
+  'settings.unrecognizedFormat': 'Unrecognized file format',
+
+  // Settings — import result summaries
+  'settings.importDuplicates': '{count} duplicates skipped',
+  'settings.importDuplicates_one': '{count} duplicate skipped',
+  'settings.importDuplicates_other': '{count} duplicates skipped',
+  'settings.importInvalid': '{count} ignored (not a duck.com address)',
+  'settings.importNothingNew': 'No new addresses to import.',
+  'settings.importedCount': 'Imported {count} addresses',
+  'settings.importedCount_one': 'Imported {count} address',
+  'settings.importedCount_other': 'Imported {count} addresses',
+  'settings.importedCountWithNotes': '{imported} — {notes}',
+
+  // Settings — backup summary dialog
+  'settings.summaryAccounts': 'Accounts: {accounts}',
+  'settings.summaryAddresses': 'Addresses: {count}',
+  'settings.summaryReverseAliases': 'Reverse aliases: {count}',
+  'settings.summarySessionIncluded': 'Session data: included',
+  'settings.summarySessionRestored': 'Session data: restored',
+  'settings.summaryNewAccounts': 'New accounts added: {count}',
+  'settings.summaryAddressCount': '{count} addresses',
+  'settings.summaryAliasCount': '{count} reverse aliases',
+  'settings.summaryAccountLine': '{account}@duck.com: +{parts}',
+  'settings.summarySkipped': 'Skipped (already exist): {parts}',
+  'settings.summaryUpToDate': 'Everything was already up to date.',
+  'settings.exportComplete': 'Export complete',
+  'settings.importComplete': 'Import complete',
+
+  // Settings — dialogs
+  'settings.popoutTitle': 'Open in new window',
+  'settings.popoutMessage':
+    "Firefox doesn't allow file selection from the popup. The extension will open in a new window where you can import your backup normally.",
+  'settings.popoutConfirm': 'Open window',
+  'settings.exportWarningTitle': 'Security warning',
+  'settings.exportWarningMessage':
+    'The exported file will contain your access token and login credentials. Keep this file secure and do not share it. Anyone with this file can access your DuckDuckGo Email account.',
+  'settings.exportWarningConfirm': 'Export anyway',
+  'settings.importConfirmTitle': 'Import backup',
+  'settings.importConfirmMessage':
+    'This backup contains session data. Importing it will add the accounts and their data to your extension. Are you sure?',
+  'settings.importConfirmButton': 'Import',
+
+  // Sync session restore prompt
+  'sync.foundTitle': 'Synced accounts found',
+  'sync.foundMessage':
+    'Found {count} synced accounts: {accounts}. Would you like to restore them?',
+  'sync.foundMessage_one':
+    'Found {count} synced account: {accounts}. Would you like to restore them?',
+  'sync.foundMessage_other':
+    'Found {count} synced accounts: {accounts}. Would you like to restore them?',
+  'sync.restore': 'Restore',
+  'sync.dataTooLarge': 'Data too large ({size}KB). Maximum is 8KB per account.',
+  'sync.addressCount': '{count} addresses',
+  'sync.aliasCount': '{count} reverse aliases',
+  'sync.sessionData': 'session data',
+  'sync.syncedParts': 'Successfully synced {parts}',
+  'sync.migrationFailed': 'Migration failed',
+  'sync.pullFailed': 'Failed to pull from sync',
+  'sync.noSyncedData': 'No synced data found',
+  'sync.quotaExceededDisabled': 'Sync quota exceeded. Sync has been disabled.',
+  'sync.disabled': 'Sync disabled',
+  'sync.notEnabled': 'Sync is not enabled',
+  'sync.noUser': 'No user logged in',
+  'sync.nothingToMigrate': 'No data to migrate',
+  'sync.quotaExceeded': 'Storage quota exceeded. Try reducing the amount of synced data.',
+
+  // Permissions
+  'permission.storage.name': 'Storage',
+  'permission.storage.description':
+    '`storage`\nRequired for the extension to function properly, to store and retrieve data locally',
+  'permission.contextMenu.name': 'Context menu',
+  'permission.contextMenu.description':
+    "`contextMenus`\nFirefox requires this permission to be listed in the manifest's permissions block at install time, [Read More](https://github.com/Lanshuns/Qwacky?tab=readme-ov-file#browser-specific-permission-handling-and-limitations)",
+  'permission.autofill.name': 'Autofill',
+  'permission.autofill.descriptionFirefox':
+    '`activeTab`, `clipboardWrite` and `scripting`\nEnables the Qwacky options in the context menu, to generate a duck address or convert a recipient into a send address',
+  'permission.autofill.descriptionChrome':
+    '`contextMenus`, `activeTab`, `clipboardWrite` and `scripting`\nEnables the Qwacky options in the context menu, to generate a duck address or convert a recipient into a send address',
+
+  // Permission toggle
+  'permissionToggle.denied': 'Permission request was denied',
+  'permissionToggle.reloading': 'Reloading to apply changes...',
+  'permissionToggle.enableFailed': 'Failed to enable feature',
+  'permissionToggle.disabling': 'Disabling {name}...',
+  'permissionToggle.disableFailed': 'Failed to disable feature',
+  'permissionToggle.error': 'An error occurred',
+  'permissionToggle.noticeTitle': 'Permissions notice',
+  'permissionToggle.tooltip':
+    'Browser additional permissions request will only appear once if not already granted.',
+  'permissionToggle.readMore': 'Read More',
+  'permissionToggle.firefox1': 'To enable this feature:',
+  'permissionToggle.firefox2': "1. Firefox will show a permissions request - click 'Allow'",
+  'permissionToggle.firefox3': '2. Return to the extension and toggle the feature again',
+  'permissionToggle.firefox4': 'You can disable this feature anytime later.',
+  'permissionToggle.chrome1': 'Chrome handles permissions differently than Firefox.',
+  'permissionToggle.chrome2':
+    "To enable this feature, Chrome will show a permission request once. After clicking 'Done', a permissions dialog may appear.",
+  'permissionToggle.chrome3':
+    "If you see a permissions dialog, click 'Allow' then return to the extension and toggle the feature again.",
+  'permissionToggle.chrome4': 'For more details, see:',
+  'permissionToggle.chromeLink': 'Browser-Specific Permission Handling and Limitations',
+
+  // Error boundary
+  'errorBoundary.title': 'Something went wrong',
+  'errorBoundary.message': 'The extension encountered an unexpected error.',
+  'errorBoundary.reload': 'Reload Extension',
+
+  // Context menu (background)
+  'contextMenu.parent': 'Qwacky',
+  'contextMenu.generate': 'Autofill duck address',
+  'contextMenu.convert': 'Convert to send address',
+
+  // Content script notifications
+  'notify.loginFirst': 'You need to login first',
+  'notify.selectRecipient': 'Select a recipient email to convert',
+  'notify.generateFailed': 'Failed to generate address. Login required?',
+  'notify.fillFailedCopied': 'Could not fill input, address copied to clipboard',
+  'notify.fillFailedNotCopied':
+    'Could not fill input or copy to clipboard. Please check permissions in settings.',
+  'notify.filledAndCopied': 'Address filled and copied to clipboard',
+  'notify.filledNotCopied':
+    'Address filled but could not copy to clipboard. Please check permissions in settings.',
+  'notify.replaceFailedCopied': 'Could not replace selection, address copied to clipboard',
+  'notify.replaceFailedNotCopied':
+    'Could not replace selection or copy to clipboard. Please check permissions in settings.',
+  'notify.convertedAndCopied': 'Converted and copied to clipboard',
+  'notify.convertedNotCopied':
+    'Converted, but could not copy to clipboard. Please check permissions in settings.',
+
+  // Service errors
+  'error.usernameRequired': 'Username is required',
+  'error.otpRequired': 'OTP is required',
+  'error.notAuthenticated': 'You need to login first',
+  'error.invalidUserData': 'Invalid user data. Please log in again.',
+  'error.noAddressReturned': 'No address returned from the server',
+  'error.otpSent': 'OTP sent to your email!',
+  'error.tooManyRequests': 'Too many requests. Please wait a moment before trying again.',
+  'error.otpSendFailed': 'Failed to send OTP. Please try again later.',
+  'error.network': 'Network error. Please check your internet connection.',
+  'error.loginFailed': 'Login failed. Please try again.',
+  'error.invalidServerResponse': 'Invalid response from server.',
+  'error.dashboardFailed': 'Failed to load dashboard data.',
+  'error.loginSuccessful': 'Login successful!',
+  'error.invalidPassphrase':
+    'Invalid passphrase. Please check the passphrase in your email and try again.',
+  'error.generateFailed': 'Failed to generate address',
+  'error.invalidResponseFormat': 'Invalid response format',
+  'error.unexpectedLogin': 'An unexpected error occurred during login',
+  'error.unexpectedVerify': 'An unexpected error occurred during verification',
+  'error.unknownGenerate': 'Unknown error generating address',
+  'error.unknownDeleteAccount': 'Unknown error deleting account',
+  'error.unknownLogout': 'Unknown error during logout',
+  'error.unknownImportAddresses': 'Unknown error importing addresses',
+  'error.unknownImportBackup': 'Unknown error importing backup',
+  'error.exportBackupFailed': 'Failed to export backup',
+  'error.importDataEmpty': 'Import data is empty or invalid',
+  'error.importMissingAddresses': 'Invalid format: missing addresses array',
+  'error.importInvalidJson': 'Invalid JSON format',
+  'error.importNoAddresses': 'No addresses found in file',
+  'error.importNoValidAddresses': 'No valid duck.com addresses found.',
+  'error.importAllExist': 'No new addresses to import. All addresses already exist.',
+  'error.importStorage': 'Storage error: {reason}',
+  'error.importSaveFailed': 'Failed to save imported addresses',
+  'error.deleteAccountFailed': 'Failed to delete account',
+  'error.userDataNotFoundLogin': 'User data not found. Please log in again.',
+  'error.userDataNotFoundLoginFirst': 'User data not found. Please log in first.',
+  'error.invalidBackupFormat': 'Invalid backup file format',
+  'error.notQwackyBackup': 'Not a valid Qwacky backup file',
+  'error.accountNotInSession': 'Current account not found in session data',
+} as const
+
+export type TranslationKey = keyof typeof en
+export type Translations = Record<TranslationKey, string>

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1,0 +1,427 @@
+import type { Translations } from './en'
+
+export const es: Translations = {
+  // Language / locale
+  'locale.tag': 'es-ES',
+  'language.en': 'English',
+  'language.es': 'Español',
+
+  // Shared
+  'common.cancel': 'Cancelar',
+  'common.confirm': 'Confirmar',
+  'common.save': 'Guardar',
+  'common.clear': 'Borrar',
+  'common.close': 'Cerrar',
+  'common.delete': 'Eliminar',
+  'common.done': 'Listo',
+  'common.ok': 'Aceptar',
+  'common.gotIt': 'Entendido',
+  'common.back': 'Atrás',
+  'common.backToDashboard': 'Volver al panel',
+  'common.copied': '¡Copiado!',
+  'common.failedToCopy': 'No se pudo copiar',
+  'common.current': '(actual)',
+  'common.unknownError': 'Error desconocido',
+
+  // Header
+  'header.switchAccount': 'Cambiar de cuenta',
+  'header.addAccount': 'Añadir cuenta',
+  'header.myAccount': 'Mi cuenta',
+  'header.settings': 'Ajustes',
+  'header.whatsNew': '¿Qué hay de nuevo?',
+  'header.about': 'Acerca de',
+  'header.logout': 'Cerrar sesión',
+  'header.logoutConfirmTitle': 'Confirmar cierre de sesión',
+  'header.logoutConfirmMessage': '¿Seguro que quieres cerrar sesión?',
+  'header.nicknameTitle': 'Editar apodo de la cuenta',
+  'header.nicknameSubtitle': 'Define un apodo personalizado para {username}',
+  'header.nicknamePlaceholder': 'Introduce un apodo (opcional)',
+  'header.support': 'Apoya el proyecto',
+  'header.openInWindow': 'Abrir en una ventana nueva',
+  'header.menu': 'Menú',
+
+  // Login
+  'login.message': 'Inicia sesión para gestionar tus direcciones {duck}',
+  'login.placeholder': 'Introduce tu usuario de duck',
+  'login.sending': 'Enviando...',
+  'login.continue': 'Continuar',
+  'login.alreadyLoggedIn': 'Esta cuenta ya tiene la sesión iniciada',
+  'login.noAccount': '¿No tienes una?',
+  'login.createNow': 'Créala ahora',
+  'login.signupTitle': 'Crear una dirección duck',
+  'login.signupMessage':
+    'Te redirigiremos a DuckDuckGo para crear tu dirección @duck.com. Cuando completes el registro, iniciarás sesión automáticamente.',
+  'login.signupConfirm': 'Continuar a DuckDuckGo',
+
+  // Auto-login (from signup)
+  'autoLogin.successTitle': 'Sesión iniciada correctamente',
+  'autoLogin.successMessage': 'Se ha iniciado sesión automáticamente como {username}@duck.com',
+  'autoLogin.failedTitle': 'Error al iniciar sesión automáticamente',
+  'autoLogin.dashboardFailed':
+    'No se pudieron cargar los datos del panel. Inicia sesión manualmente.',
+  'autoLogin.invalidResponse': 'Respuesta no válida del servidor. Inicia sesión manualmente.',
+  'autoLogin.noUsername': 'No se pudo determinar el nombre de usuario. Inicia sesión manualmente.',
+  'autoLogin.generic': 'Error al iniciar sesión automáticamente. Inicia sesión manualmente.',
+  'autoLogin.alreadyLoggedIn': 'La sesión ya está iniciada.',
+  'autoLogin.invalidToken': 'Token no válido',
+  'autoLogin.invalidUsername': 'Nombre de usuario no válido',
+  'autoLogin.invalidCredentials': 'Credenciales no válidas',
+
+  // OTP
+  'otp.backToLogin': 'Volver al inicio de sesión',
+  'otp.loggedInAs': 'Sesión iniciada como {username}@duck.com',
+  'otp.message': 'Se ha enviado una frase de acceso de un solo uso a tu correo',
+  'otp.placeholder': 'p. ej. morality landless proved paprika',
+  'otp.verifying': 'Verificando...',
+  'otp.verify': 'Verificar código',
+  'otp.resend': 'Reenviar frase de acceso',
+  'otp.resendSuccess': 'Se ha enviado una nueva frase de acceso a tu correo.',
+  'otp.resendFailed': 'No se pudo reenviar la frase de acceso.',
+  'otp.switchFailed': 'No se pudo cambiar a la nueva cuenta',
+  'otp.userDataFailed': 'No se pudieron obtener los datos del usuario',
+  'otp.verifyFailed': 'No se pudo verificar el código',
+  'otp.genericError': 'Se produjo un error. Inténtalo de nuevo.',
+  'otp.troubleToggle': '¿Problemas para iniciar sesión?',
+  'otp.hint':
+    '¿No lo has recibido? Revisa tu carpeta de spam o correo no deseado. Algunos proveedores de correo (como ProtonMail) pueden retrasar o filtrar los mensajes de DuckDuckGo.',
+
+  // Dashboard
+  'dashboard.tabGenerate': 'Generar',
+  'dashboard.tabSend': 'Enviar',
+  'dashboard.generating': 'Generando...',
+  'dashboard.generate': 'Generar dirección nueva',
+  'dashboard.loadFailed': 'No se pudieron cargar los datos',
+  'dashboard.generateFailed': 'No se pudo generar la dirección',
+  'dashboard.hideInstructions': 'Ocultar',
+  'dashboard.howToUse': 'Cómo se usa',
+  'dashboard.step1': 'Introduce el correo del destinatario y pulsa <b>Convertir</b>',
+  'dashboard.step2': 'Pega el resultado en el campo <b>Para</b> de tu cliente de correo',
+  'dashboard.step3': 'Envía desde el correo vinculado a tu cuenta de DDG',
+  'dashboard.learnMore': 'Más información',
+  'dashboard.from': 'De:',
+  'dashboard.recipientPlaceholder': 'alguien@correo.com',
+  'dashboard.convert': 'Convertir',
+  'dashboard.sendFrom': 'Enviar desde',
+  'dashboard.closePicker': 'Cerrar selector',
+  'dashboard.searchAddresses': 'Buscar direcciones...',
+  'dashboard.personalAddress': 'Dirección personal',
+
+  // Generated address list
+  'list.generated.title': 'Direcciones generadas',
+  'list.generated.itemsLabel': 'direcciones',
+  'list.generated.emptyTitle': 'Aún no hay direcciones',
+  'list.generated.emptySubtitle': 'Pulsa el botón de arriba para generar tu primera dirección',
+  'list.generated.searchPlaceholder': 'Buscar direcciones o notas...',
+  'list.generated.deleteTitle': 'Eliminar dirección',
+  'list.generated.deleteMessage': '¿Seguro que quieres eliminar esta dirección\n({key}@duck.com)?',
+  'list.generated.clearTitle': 'Borrar todas las direcciones',
+  'list.generated.clearMessage':
+    '¿Seguro que quieres borrar todas las direcciones?\n\nEsta acción no se puede deshacer.',
+
+  // Reverse alias list
+  'list.send.title': 'Historial',
+  'list.send.itemsLabel': 'alias',
+  'list.send.emptyTitle': 'Aún no hay historial',
+  'list.send.emptySubtitle': 'Convierte arriba el correo de un destinatario para empezar',
+  'list.send.searchPlaceholder': 'Buscar correos o notas...',
+  'list.send.deleteTitle': 'Eliminar alias inverso',
+  'list.send.deleteMessage': '¿Seguro que quieres eliminar el alias inverso de\n{key}?',
+  'list.send.clearTitle': 'Borrar todo el historial',
+  'list.send.clearMessage':
+    '¿Seguro que quieres borrar todo el historial de alias inversos?\n\nEsta acción no se puede deshacer.',
+
+  // List UI (shared by both lists)
+  'list.copyItem': 'Copiar {value}',
+  'list.copyReverseAlias': 'Copiar el alias inverso de {value}',
+  'list.removeTag': 'Quitar la etiqueta {tag}',
+  'list.addTagPlaceholder': 'Añadir etiqueta...',
+  'list.addTag': 'Añadir etiqueta',
+  'list.closeTagInput': 'Cerrar el campo de etiquetas',
+  'list.notesPlaceholder': 'Añadir notas...',
+  'list.editNotes': 'Editar notas',
+  'list.saveNotes': 'Guardar notas',
+  'list.cancelEditing': 'Cancelar edición',
+  'list.editTags': 'Editar etiquetas',
+  'list.untagged': 'Sin etiquetas',
+  'list.sortNewest': 'Recientes',
+  'list.sortOldest': 'Antiguas',
+  'list.sortBy': 'Ordenar por: {order}',
+  'list.noResultsTitle': 'No se encontraron resultados',
+  'list.noResultsSubtitle': 'Prueba a ajustar la búsqueda o el filtro',
+  'list.clearAllItems': 'Borrar todas las {items}',
+  'list.showItems': 'Mostrar {items}',
+  'list.hideItems': 'Ocultar {items}',
+  'list.searchItems': 'Buscar {items}',
+  'list.clearSearch': 'Borrar búsqueda',
+  'list.groupByTag': 'Agrupar por etiqueta',
+  'list.group': 'Agrupar',
+  'list.filterAll': 'Todas',
+  'list.showingCount': 'Mostrando {shown} de {total} {items}',
+  'list.clearAll': 'Borrar todo',
+
+  // User info card
+  'userInfo.title': 'Mi cuenta',
+  'userInfo.show': 'Mostrar la información del usuario',
+  'userInfo.hide': 'Ocultar la información del usuario',
+  'userInfo.username': 'Usuario de duck',
+  'userInfo.email': 'Correo de reenvío',
+  'userInfo.totalGenerated': 'Total generadas',
+  'userInfo.invites': 'Invitaciones',
+
+  // My account page
+  'myAccount.manage': 'Gestionar tu cuenta de duck',
+  'myAccount.removing': 'Eliminando...',
+  'myAccount.remove': 'Eliminar los datos locales de la cuenta',
+  'myAccount.removeTitle': 'Eliminar los datos locales de la cuenta',
+  'myAccount.removeMessage':
+    'Vas a eliminar {account} junto con sus {data} de este dispositivo y de la sincronización. Tu cuenta de DuckDuckGo no se verá afectada. Esta acción no se puede deshacer.',
+  'myAccount.thisAccount': 'esta cuenta',
+  'myAccount.savedAddresses': '{count} direcciones guardadas',
+  'myAccount.savedAddresses_one': '{count} dirección guardada',
+  'myAccount.savedAddresses_other': '{count} direcciones guardadas',
+  'myAccount.reverseAliases': '{count} alias inversos',
+  'myAccount.reverseAliases_one': '{count} alias inverso',
+  'myAccount.reverseAliases_other': '{count} alias inversos',
+  'myAccount.addressesAndAliases': '{addresses} y {aliases}',
+  'myAccount.removeFailed': 'No se pudo eliminar la cuenta',
+  'myAccount.noAccountSelected': 'No hay ninguna cuenta seleccionada',
+
+  // About page
+  'about.support': 'Apoya el proyecto',
+  'about.github': 'Repositorio de GitHub',
+  'about.firefoxStore': 'Complementos de Firefox',
+  'about.chromeStore': 'Chrome Web Store',
+
+  // Changelog page
+  'changelog.loading': 'Cargando el registro de cambios...',
+  'changelog.error': 'No se pudo cargar el registro de cambios. Inténtalo de nuevo más tarde.',
+  'changelog.loadFailed': 'No se pudo cargar el registro de cambios',
+  'changelog.heading': '¿Qué hay de nuevo?',
+
+  // Settings — appearance
+  'settings.appearance': 'Apariencia',
+  'settings.theme': 'Tema',
+  'settings.themeLight': 'Claro',
+  'settings.themeDark': 'Oscuro',
+  'settings.themeSystem': 'Sistema',
+  'settings.language': 'Idioma',
+  'settings.timeFormat24h': 'Formato de 24 horas',
+
+  // Settings — permissions
+  'settings.permissions': 'Permisos y funciones',
+
+  // Settings — sync
+  'settings.sync': 'Sincronización',
+  'settings.syncOptions': 'Opciones de sincronización',
+  'settings.syncAddresses': 'Direcciones',
+  'settings.syncReverseAliases': 'Alias inversos',
+  'settings.syncSessionData': 'Datos de sesión',
+  'settings.syncSessionHint': '(datos de acceso y ajustes)',
+  'settings.syncTokenWarningFirefox':
+    'Los datos de sesión incluyen tus tokens de acceso. Firefox los cifra durante la sincronización, pero se guardan en tu cuenta de Mozilla.',
+  'settings.syncTokenWarningChrome':
+    'Los datos de sesión incluyen tus tokens de acceso. Chrome los cifra durante la sincronización, pero se guardan en tu cuenta de Google.',
+  'settings.syncStatus': 'Estado:',
+  'settings.syncLastSynced': 'Última sincronización: {date}',
+  'settings.syncNever': 'Nunca sincronizado',
+  'settings.syncRefresh': 'Actualizar',
+  'settings.syncStorageUsed': 'Almacenamiento usado:',
+  'settings.syncAutoDisabled':
+    'La sincronización se desactivó automáticamente porque se superó la cuota de almacenamiento.',
+  'settings.allAccounts': 'Todas las cuentas',
+  'settings.selectAccounts': 'Selecciona las cuentas...',
+  'settings.accountsSelected': '{count} cuentas seleccionadas',
+
+  // Settings — backup & restore
+  'settings.backup': 'Copia de seguridad y restauración',
+  'settings.exporting': 'Exportando...',
+  'settings.exportBackup': 'Exportar copia de seguridad',
+  'settings.importing': 'Importando...',
+  'settings.importBackup': 'Importar copia de seguridad',
+  'settings.importHint':
+    'La importación acepta una copia de seguridad de Qwacky (.json) o un archivo .txt con una lista de direcciones duck.com existentes, una por línea.',
+  'settings.exportOptions': 'Opciones de exportación',
+  'settings.includeSession': 'Incluir la sesión',
+  'settings.exportFailed': 'No se pudo exportar la copia de seguridad',
+  'settings.importFailedInvalidFile': 'Error al importar: archivo no válido',
+  'settings.importFailed': 'Error al importar',
+  'settings.importFailedWithReason': 'Error al importar: {reason}',
+  'settings.unrecognizedFormat': 'Formato de archivo no reconocido',
+
+  // Settings — import result summaries
+  'settings.importDuplicates': '{count} duplicadas omitidas',
+  'settings.importDuplicates_one': '{count} duplicada omitida',
+  'settings.importDuplicates_other': '{count} duplicadas omitidas',
+  'settings.importInvalid': '{count} ignoradas (no son direcciones duck.com)',
+  'settings.importNothingNew': 'No hay direcciones nuevas que importar.',
+  'settings.importedCount': '{count} direcciones importadas',
+  'settings.importedCount_one': '{count} dirección importada',
+  'settings.importedCount_other': '{count} direcciones importadas',
+  'settings.importedCountWithNotes': '{imported} — {notes}',
+
+  // Settings — backup summary dialog
+  'settings.summaryAccounts': 'Cuentas: {accounts}',
+  'settings.summaryAddresses': 'Direcciones: {count}',
+  'settings.summaryReverseAliases': 'Alias inversos: {count}',
+  'settings.summarySessionIncluded': 'Datos de sesión: incluidos',
+  'settings.summarySessionRestored': 'Datos de sesión: restaurados',
+  'settings.summaryNewAccounts': 'Cuentas nuevas añadidas: {count}',
+  'settings.summaryAddressCount': '{count} direcciones',
+  'settings.summaryAliasCount': '{count} alias inversos',
+  'settings.summaryAccountLine': '{account}@duck.com: +{parts}',
+  'settings.summarySkipped': 'Omitidas (ya existían): {parts}',
+  'settings.summaryUpToDate': 'Ya estaba todo actualizado.',
+  'settings.exportComplete': 'Exportación completada',
+  'settings.importComplete': 'Importación completada',
+
+  // Settings — dialogs
+  'settings.popoutTitle': 'Abrir en una ventana nueva',
+  'settings.popoutMessage':
+    'Firefox no permite seleccionar archivos desde la ventana emergente. La extensión se abrirá en una ventana nueva donde podrás importar tu copia de seguridad con normalidad.',
+  'settings.popoutConfirm': 'Abrir ventana',
+  'settings.exportWarningTitle': 'Advertencia de seguridad',
+  'settings.exportWarningMessage':
+    'El archivo exportado contendrá tu token de acceso y tus credenciales de inicio de sesión. Guárdalo en un lugar seguro y no lo compartas. Cualquiera que tenga este archivo puede acceder a tu cuenta de DuckDuckGo Email.',
+  'settings.exportWarningConfirm': 'Exportar de todos modos',
+  'settings.importConfirmTitle': 'Importar copia de seguridad',
+  'settings.importConfirmMessage':
+    'Esta copia de seguridad contiene datos de sesión. Al importarla se añadirán las cuentas y sus datos a tu extensión. ¿Seguro que quieres continuar?',
+  'settings.importConfirmButton': 'Importar',
+
+  // Sync session restore prompt
+  'sync.foundTitle': 'Se encontraron cuentas sincronizadas',
+  'sync.foundMessage':
+    'Se encontraron {count} cuentas sincronizadas: {accounts}. ¿Quieres restaurarlas?',
+  'sync.foundMessage_one':
+    'Se encontró {count} cuenta sincronizada: {accounts}. ¿Quieres restaurarla?',
+  'sync.foundMessage_other':
+    'Se encontraron {count} cuentas sincronizadas: {accounts}. ¿Quieres restaurarlas?',
+  'sync.restore': 'Restaurar',
+  'sync.dataTooLarge': 'Los datos son demasiado grandes ({size} KB). El máximo es 8 KB por cuenta.',
+  'sync.addressCount': '{count} direcciones',
+  'sync.aliasCount': '{count} alias inversos',
+  'sync.sessionData': 'datos de sesión',
+  'sync.syncedParts': 'Se sincronizaron correctamente: {parts}',
+  'sync.migrationFailed': 'Error en la migración',
+  'sync.pullFailed': 'No se pudieron obtener los datos sincronizados',
+  'sync.noSyncedData': 'No se encontraron datos sincronizados',
+  'sync.quotaExceededDisabled':
+    'Se superó la cuota de sincronización. La sincronización se ha desactivado.',
+  'sync.disabled': 'Sincronización desactivada',
+  'sync.notEnabled': 'La sincronización no está activada',
+  'sync.noUser': 'No hay ninguna sesión iniciada',
+  'sync.nothingToMigrate': 'No hay datos que migrar',
+  'sync.quotaExceeded':
+    'Se superó la cuota de almacenamiento. Prueba a reducir la cantidad de datos sincronizados.',
+
+  // Permissions
+  'permission.storage.name': 'Almacenamiento',
+  'permission.storage.description':
+    '`storage`\nNecesario para que la extensión funcione correctamente, para guardar y recuperar datos localmente',
+  'permission.contextMenu.name': 'Menú contextual',
+  'permission.contextMenu.description':
+    '`contextMenus`\nFirefox exige que este permiso figure en el bloque de permisos del manifiesto en el momento de la instalación. [Más información](https://github.com/Lanshuns/Qwacky?tab=readme-ov-file#browser-specific-permission-handling-and-limitations)',
+  'permission.autofill.name': 'Autocompletar',
+  'permission.autofill.descriptionFirefox':
+    '`activeTab`, `clipboardWrite` y `scripting`\nActiva las opciones de Qwacky en el menú contextual para generar una dirección duck o convertir un destinatario en una dirección de envío',
+  'permission.autofill.descriptionChrome':
+    '`contextMenus`, `activeTab`, `clipboardWrite` y `scripting`\nActiva las opciones de Qwacky en el menú contextual para generar una dirección duck o convertir un destinatario en una dirección de envío',
+
+  // Permission toggle
+  'permissionToggle.denied': 'Se denegó la solicitud de permisos',
+  'permissionToggle.reloading': 'Recargando para aplicar los cambios...',
+  'permissionToggle.enableFailed': 'No se pudo activar la función',
+  'permissionToggle.disabling': 'Desactivando {name}...',
+  'permissionToggle.disableFailed': 'No se pudo desactivar la función',
+  'permissionToggle.error': 'Se produjo un error',
+  'permissionToggle.noticeTitle': 'Aviso de permisos',
+  'permissionToggle.tooltip':
+    'La solicitud de permisos adicionales del navegador solo aparecerá una vez si aún no se han concedido.',
+  'permissionToggle.readMore': 'Más información',
+  'permissionToggle.firefox1': 'Para activar esta función:',
+  'permissionToggle.firefox2':
+    '1. Firefox mostrará una solicitud de permisos: pulsa «Permitir»',
+  'permissionToggle.firefox3': '2. Vuelve a la extensión y activa la función de nuevo',
+  'permissionToggle.firefox4': 'Puedes desactivar esta función en cualquier momento.',
+  'permissionToggle.chrome1': 'Chrome gestiona los permisos de forma distinta a Firefox.',
+  'permissionToggle.chrome2':
+    'Para activar esta función, Chrome mostrará una solicitud de permisos una sola vez. Después de pulsar «Listo», puede aparecer un diálogo de permisos.',
+  'permissionToggle.chrome3':
+    'Si aparece un diálogo de permisos, pulsa «Permitir», vuelve a la extensión y activa la función de nuevo.',
+  'permissionToggle.chrome4': 'Para más detalles, consulta:',
+  'permissionToggle.chromeLink':
+    'Gestión y limitaciones de permisos según el navegador',
+
+  // Error boundary
+  'errorBoundary.title': 'Algo salió mal',
+  'errorBoundary.message': 'La extensión encontró un error inesperado.',
+  'errorBoundary.reload': 'Recargar la extensión',
+
+  // Context menu (background)
+  'contextMenu.parent': 'Qwacky',
+  'contextMenu.generate': 'Autocompletar con una dirección duck',
+  'contextMenu.convert': 'Convertir en dirección de envío',
+
+  // Content script notifications
+  'notify.loginFirst': 'Primero tienes que iniciar sesión',
+  'notify.selectRecipient': 'Selecciona el correo de un destinatario para convertirlo',
+  'notify.generateFailed': 'No se pudo generar la dirección. ¿Has iniciado sesión?',
+  'notify.fillFailedCopied':
+    'No se pudo rellenar el campo; la dirección se copió al portapapeles',
+  'notify.fillFailedNotCopied':
+    'No se pudo rellenar el campo ni copiar al portapapeles. Revisa los permisos en los ajustes.',
+  'notify.filledAndCopied': 'Dirección rellenada y copiada al portapapeles',
+  'notify.filledNotCopied':
+    'Dirección rellenada, pero no se pudo copiar al portapapeles. Revisa los permisos en los ajustes.',
+  'notify.replaceFailedCopied':
+    'No se pudo reemplazar la selección; la dirección se copió al portapapeles',
+  'notify.replaceFailedNotCopied':
+    'No se pudo reemplazar la selección ni copiar al portapapeles. Revisa los permisos en los ajustes.',
+  'notify.convertedAndCopied': 'Convertido y copiado al portapapeles',
+  'notify.convertedNotCopied':
+    'Convertido, pero no se pudo copiar al portapapeles. Revisa los permisos en los ajustes.',
+
+  // Service errors
+  'error.usernameRequired': 'El nombre de usuario es obligatorio',
+  'error.otpRequired': 'El código de un solo uso es obligatorio',
+  'error.notAuthenticated': 'Primero tienes que iniciar sesión',
+  'error.invalidUserData': 'Datos de usuario no válidos. Inicia sesión de nuevo.',
+  'error.noAddressReturned': 'El servidor no devolvió ninguna dirección',
+  'error.otpSent': '¡Se envió el código de un solo uso a tu correo!',
+  'error.tooManyRequests': 'Demasiadas solicitudes. Espera un momento antes de volver a intentarlo.',
+  'error.otpSendFailed':
+    'No se pudo enviar el código de un solo uso. Inténtalo de nuevo más tarde.',
+  'error.network': 'Error de red. Comprueba tu conexión a internet.',
+  'error.loginFailed': 'No se pudo iniciar sesión. Inténtalo de nuevo.',
+  'error.invalidServerResponse': 'Respuesta no válida del servidor.',
+  'error.dashboardFailed': 'No se pudieron cargar los datos del panel.',
+  'error.loginSuccessful': '¡Sesión iniciada correctamente!',
+  'error.invalidPassphrase':
+    'Frase de acceso no válida. Comprueba la frase de acceso de tu correo e inténtalo de nuevo.',
+  'error.generateFailed': 'No se pudo generar la dirección',
+  'error.invalidResponseFormat': 'Formato de respuesta no válido',
+  'error.unexpectedLogin': 'Se produjo un error inesperado al iniciar sesión',
+  'error.unexpectedVerify': 'Se produjo un error inesperado durante la verificación',
+  'error.unknownGenerate': 'Error desconocido al generar la dirección',
+  'error.unknownDeleteAccount': 'Error desconocido al eliminar la cuenta',
+  'error.unknownLogout': 'Error desconocido al cerrar sesión',
+  'error.unknownImportAddresses': 'Error desconocido al importar las direcciones',
+  'error.unknownImportBackup': 'Error desconocido al importar la copia de seguridad',
+  'error.exportBackupFailed': 'No se pudo exportar la copia de seguridad',
+  'error.importDataEmpty': 'Los datos de importación están vacíos o no son válidos',
+  'error.importMissingAddresses': 'Formato no válido: falta el array de direcciones',
+  'error.importInvalidJson': 'Formato JSON no válido',
+  'error.importNoAddresses': 'No se encontraron direcciones en el archivo',
+  'error.importNoValidAddresses': 'No se encontraron direcciones duck.com válidas.',
+  'error.importAllExist': 'No hay direcciones nuevas que importar. Todas ya existen.',
+  'error.importStorage': 'Error de almacenamiento: {reason}',
+  'error.importSaveFailed': 'No se pudieron guardar las direcciones importadas',
+  'error.deleteAccountFailed': 'No se pudo eliminar la cuenta',
+  'error.userDataNotFoundLogin':
+    'No se encontraron los datos del usuario. Inicia sesión de nuevo.',
+  'error.userDataNotFoundLoginFirst':
+    'No se encontraron los datos del usuario. Inicia sesión primero.',
+  'error.invalidBackupFormat': 'Formato de archivo de copia de seguridad no válido',
+  'error.notQwackyBackup': 'No es un archivo de copia de seguridad válido de Qwacky',
+  'error.accountNotInSession': 'La cuenta actual no se encuentra en los datos de sesión',
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import { App } from './App'
 import { AppProvider } from './context/AppContext'
 import { PermissionProvider } from './context/PermissionContext'
 import { ErrorBoundary } from './components/ErrorBoundary'
+import { I18nProvider } from './i18n'
 
 const container = document.getElementById('root')
 if (!container) {
@@ -12,12 +13,14 @@ if (!container) {
 
 createRoot(container).render(
   <React.StrictMode>
-    <ErrorBoundary>
-      <AppProvider>
-        <PermissionProvider>
-          <App />
-        </PermissionProvider>
-      </AppProvider>
-    </ErrorBoundary>
+    <I18nProvider>
+      <ErrorBoundary>
+        <AppProvider>
+          <PermissionProvider>
+            <App />
+          </PermissionProvider>
+        </AppProvider>
+      </ErrorBoundary>
+    </I18nProvider>
   </React.StrictMode>
 )

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,5 +1,6 @@
 import { MdArrowBack, MdOpenInNew, MdFavorite } from 'react-icons/md'
 import { FaGithub } from 'react-icons/fa'
+import { useI18n } from '../i18n'
 import { BackButton } from '../styles/SharedStyles'
 import { AboutContainer, AppInfo, AppLogo, AppName, AppVersion, LinksSection, LinkItem } from '../styles/pages.styles'
 
@@ -14,11 +15,13 @@ const STORE_URL = isFirefox
   : 'https://chromewebstore.google.com/detail/qwacky/kieehbhdbincplacegpjdkoglfakboeo'
 
 export const About = ({ onBack }: AboutProps) => {
+  const { t } = useI18n()
+
   return (
     <AboutContainer>
       <BackButton onClick={onBack}>
         <MdArrowBack size={20} />
-        Back
+        {t('common.back')}
       </BackButton>
 
       <AppInfo>
@@ -30,17 +33,17 @@ export const About = ({ onBack }: AboutProps) => {
       <LinksSection>
         <LinkItem href="https://github.com/Lanshuns/Qwacky#-support-the-project" target="_blank" rel="noopener noreferrer">
           <MdFavorite size={20} />
-          Support the project
+          {t('about.support')}
           <MdOpenInNew size={16} />
         </LinkItem>
         <LinkItem href="https://github.com/Lanshuns/Qwacky" target="_blank" rel="noopener noreferrer">
           <FaGithub size={20} />
-          GitHub repository
+          {t('about.github')}
           <MdOpenInNew size={16} />
         </LinkItem>
         <LinkItem href={STORE_URL} target="_blank" rel="noopener noreferrer">
           <MdOpenInNew size={20} />
-          {isFirefox ? 'Firefox add-ons' : 'Chrome web store'}
+          {isFirefox ? t('about.firefoxStore') : t('about.chromeStore')}
           <MdOpenInNew size={16} />
         </LinkItem>
       </LinksSection>

--- a/src/pages/Changelog.tsx
+++ b/src/pages/Changelog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { MdArrowBack } from 'react-icons/md';
 import Markdown from 'react-markdown';
+import { useI18n } from '../i18n';
 import { BackButton } from '../styles/SharedStyles';
 import { ChangelogContainer, ChangelogContent, ChangelogLoadingMessage, ChangelogErrorMessage } from '../styles/pages.styles';
 
@@ -9,6 +10,7 @@ interface ChangelogProps {
 }
 
 export const Changelog = ({ onBack }: ChangelogProps) => {
+  const { t } = useI18n();
   const [changelog, setChangelog] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -18,29 +20,29 @@ export const Changelog = ({ onBack }: ChangelogProps) => {
       try {
         const response = await fetch(chrome.runtime.getURL('CHANGELOG.md'));
         if (!response.ok) {
-          throw new Error('Failed to load changelog');
+          throw new Error(t('changelog.loadFailed'));
         }
         const text = await response.text();
-        setChangelog(text.replace(/^# Changelog$/m, "# What's new?"));
+        setChangelog(text.replace(/^# Changelog$/m, `# ${t('changelog.heading')}`));
       } catch (err) {
         console.error('Error loading changelog:', err);
-        setError('Could not load changelog. Please try again later.');
+        setError(t('changelog.error'));
       } finally {
         setLoading(false);
       }
     };
 
     fetchChangelog();
-  }, []);
+  }, [t]);
 
   return (
     <ChangelogContainer>
       <BackButton onClick={onBack}>
         <MdArrowBack size={20} />
-        Back to Dashboard
+        {t('common.backToDashboard')}
       </BackButton>
 
-      {loading && <ChangelogLoadingMessage>Loading changelog...</ChangelogLoadingMessage>}
+      {loading && <ChangelogLoadingMessage>{t('changelog.loading')}</ChangelogLoadingMessage>}
       {error && <ChangelogErrorMessage>{error}</ChangelogErrorMessage>}
 
       {!loading && !error && (

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,6 +5,7 @@ import { DuckService } from "../services/DuckService";
 import { StorageService } from "../services/StorageService";
 import { ReverseAlias, TimeFormat } from "../types";
 import { useNotification } from "../components/Notification";
+import { RichText, useI18n } from "../i18n";
 
 import { ItemListSection, ListItem, ListConfig } from "../components/AddressListSection";
 import { DashboardTabs } from "../components/DashboardTabs";
@@ -36,34 +37,9 @@ interface StoredAddress {
   tags?: string[];
 }
 
-const GENERATE_LIST_CONFIG: ListConfig = {
-  title: "Generated addresses",
-  itemsLabel: "addresses",
-  emptyTitle: "No addresses yet",
-  emptySubtitle: "Click the button above to generate your first address",
-  searchPlaceholder: "Search addresses or notes...",
-  deleteTitle: "Delete address",
-  getDeleteMessage: (key) => `Are you sure you want to delete this address\n(${key}@duck.com)?`,
-  clearTitle: "Clear all addresses",
-  clearMessage: "Are you sure you want to clear all addresses?\n\nThis action cannot be undone.",
-  hideStorageKey: "hide_generated_addresses",
-};
-
-const SEND_LIST_CONFIG: ListConfig = {
-  title: "History",
-  itemsLabel: "aliases",
-  emptyTitle: "No history yet",
-  emptySubtitle: "Convert a recipient email above to get started",
-  searchPlaceholder: "Search emails or notes...",
-  deleteTitle: "Delete reverse alias",
-  getDeleteMessage: (key) => `Are you sure you want to delete the reverse alias for\n${key}?`,
-  clearTitle: "Clear all history",
-  clearMessage: "Are you sure you want to clear all reverse alias history?\n\nThis action cannot be undone.",
-  hideStorageKey: "hide_reverse_aliases",
-};
-
 export const Dashboard = () => {
   const { userData, currentAccount } = useApp();
+  const { t, localeTag } = useI18n();
   const [addresses, setAddresses] = useState<StoredAddress[]>([]);
   const [loading, setLoading] = useState(false);
   const [autoEditAddress, setAutoEditAddress] = useState<string | null>(null);
@@ -79,6 +55,32 @@ export const Dashboard = () => {
   const storageService = useMemo(() => new StorageService(), []);
   const [timeFormat, setTimeFormat] = useState<TimeFormat>('12h');
   const { showNotification, NotificationRenderer } = useNotification();
+
+  const generateListConfig: ListConfig = useMemo(() => ({
+    title: t("list.generated.title"),
+    itemsLabel: t("list.generated.itemsLabel"),
+    emptyTitle: t("list.generated.emptyTitle"),
+    emptySubtitle: t("list.generated.emptySubtitle"),
+    searchPlaceholder: t("list.generated.searchPlaceholder"),
+    deleteTitle: t("list.generated.deleteTitle"),
+    getDeleteMessage: (key) => t("list.generated.deleteMessage", { key }),
+    clearTitle: t("list.generated.clearTitle"),
+    clearMessage: t("list.generated.clearMessage"),
+    hideStorageKey: "hide_generated_addresses",
+  }), [t]);
+
+  const sendListConfig: ListConfig = useMemo(() => ({
+    title: t("list.send.title"),
+    itemsLabel: t("list.send.itemsLabel"),
+    emptyTitle: t("list.send.emptyTitle"),
+    emptySubtitle: t("list.send.emptySubtitle"),
+    searchPlaceholder: t("list.send.searchPlaceholder"),
+    deleteTitle: t("list.send.deleteTitle"),
+    getDeleteMessage: (key) => t("list.send.deleteMessage", { key }),
+    clearTitle: t("list.send.clearTitle"),
+    clearMessage: t("list.send.clearMessage"),
+    hideStorageKey: "hide_reverse_aliases",
+  }), [t]);
 
   useEffect(() => {
     chrome.storage.local.get('dashboardActiveTab', (result) => {
@@ -109,7 +111,7 @@ export const Dashboard = () => {
           setReverseAliases(loadedAliases);
         } catch (error) {
           console.error('Error loading data:', error);
-          showNotification("Failed to load data");
+          showNotification(t("dashboard.loadFailed"));
           setAddresses([]);
           setReverseAliases([]);
         }
@@ -125,22 +127,22 @@ export const Dashboard = () => {
   const copyToClipboard = useCallback(async (text: string, event?: MouseEvent) => {
     try {
       await navigator.clipboard.writeText(text);
-      showNotification("Copied!", event);
+      showNotification(t("common.copied"), event);
     } catch {
-      showNotification("Failed to copy", event);
+      showNotification(t("common.failedToCopy"), event);
     }
   }, [showNotification]);
 
   const formatTime = useCallback((timestamp: number) => {
     const date = new Date(timestamp);
-    return date.toLocaleString("en-US", {
+    return date.toLocaleString(localeTag, {
       hour: "numeric",
       minute: "numeric",
       hour12: timeFormat === '12h',
       month: "short",
       day: "numeric",
     });
-  }, [timeFormat]);
+  }, [timeFormat, localeTag]);
 
   const generateNewAddress = async () => {
     setLoading(true);
@@ -159,7 +161,7 @@ export const Dashboard = () => {
       }
     } catch (error) {
       console.error("Error generating address:", error);
-      showNotification("Failed to generate address");
+      showNotification(t("dashboard.generateFailed"));
     } finally {
       setLoading(false);
     }
@@ -239,7 +241,7 @@ export const Dashboard = () => {
 
     try { await navigator.clipboard.writeText(alias); } catch {}
     const nativeEvent = event && 'clientX' in event.nativeEvent ? event.nativeEvent as MouseEvent : undefined;
-    showNotification("Copied!", nativeEvent);
+    showNotification(t("common.copied"), nativeEvent);
     setRecipientEmail("");
     setAutoEditAlias(email);
   };
@@ -288,12 +290,12 @@ export const Dashboard = () => {
       key: addr.value,
       primaryText: addr.value + "@duck.com",
       copyText: addr.value + "@duck.com",
-      copyLabel: `Copy ${addr.value}@duck.com`,
+      copyLabel: t("list.copyItem", { value: addr.value + "@duck.com" }),
       timestamp: addr.timestamp,
       notes: addr.notes,
       tags: addr.tags || [],
     })),
-    [addresses]
+    [addresses, t]
   );
 
   const reverseAliasItems: ListItem[] = useMemo(() =>
@@ -302,12 +304,12 @@ export const Dashboard = () => {
       primaryText: a.recipientEmail,
       secondaryText: a.alias,
       copyText: a.alias,
-      copyLabel: `Copy reverse alias for ${a.recipientEmail}`,
+      copyLabel: t("list.copyReverseAlias", { value: a.recipientEmail }),
       timestamp: a.timestamp,
       notes: a.notes,
       tags: a.tags || [],
     })),
-    [reverseAliases]
+    [reverseAliases, t]
   );
 
   if (!userData) return null;
@@ -319,11 +321,11 @@ export const Dashboard = () => {
       {activeTab === 'generate' && (
         <>
           <GenerateButton onClick={generateNewAddress} disabled={loading}>
-            {loading ? "Generating..." : "Generate new address"}
+            {loading ? t("dashboard.generating") : t("dashboard.generate")}
           </GenerateButton>
           <ItemListSection
             items={addressItems}
-            config={GENERATE_LIST_CONFIG}
+            config={generateListConfig}
             copyToClipboard={copyToClipboard}
             formatTime={formatTime}
             onUpdateNotes={handleUpdateAddressNotes}
@@ -342,29 +344,29 @@ export const Dashboard = () => {
           <ReverseAliasSection>
             <InstructionsToggle onClick={() => setShowInstructions(prev => !prev)}>
               <MdInfo size={14} />
-              {showInstructions ? 'Hide' : 'How to use'}
+              {showInstructions ? t('dashboard.hideInstructions') : t('dashboard.howToUse')}
             </InstructionsToggle>
 
             {showInstructions && (
               <>
                 <ReverseAliasSteps>
-                  <li>Enter recipient's email & click <strong>Convert</strong></li>
-                  <li>Paste the result as <strong>To</strong> in your email client</li>
-                  <li>Send from the email linked to your DDG account</li>
+                  <li><RichText text={t('dashboard.step1')} /></li>
+                  <li><RichText text={t('dashboard.step2')} /></li>
+                  <li><RichText text={t('dashboard.step3')} /></li>
                 </ReverseAliasSteps>
                 <LearnMoreLink
                   href="https://duckduckgo.com/duckduckgo-help-pages/email-protection/duck-addresses/how-do-i-compose-a-new-email"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Learn more <MdOpenInNew size={12} />
+                  {t('dashboard.learnMore')} <MdOpenInNew size={12} />
                 </LearnMoreLink>
               </>
             )}
 
             {addresses.length > 0 && (
               <SenderSelector onClick={() => { setShowAliasPicker(true); setPickerSearch(''); }}>
-                <span>From:</span>
+                <span>{t('dashboard.from')}</span>
                 <span>{(effectiveSender || userData?.user.username) + '@duck.com'}</span>
                 <MdKeyboardArrowDown size={18} />
               </SenderSelector>
@@ -373,7 +375,7 @@ export const Dashboard = () => {
             <ReverseAliasInputRow>
               <ReverseAliasInput
                 type="email"
-                placeholder="someone@email.com"
+                placeholder={t('dashboard.recipientPlaceholder')}
                 value={recipientEmail}
                 onChange={(e) => setRecipientEmail(e.target.value)}
                 onKeyDown={(e) => {
@@ -384,7 +386,7 @@ export const Dashboard = () => {
                 onClick={handleConvertReverseAlias}
                 disabled={!recipientEmail.trim().includes("@")}
               >
-                Convert
+                {t('dashboard.convert')}
               </ReverseAliasConvertButton>
             </ReverseAliasInputRow>
           </ReverseAliasSection>
@@ -393,13 +395,13 @@ export const Dashboard = () => {
             <DialogOverlay onClick={(e) => { if (e.target === e.currentTarget) { setShowAliasPicker(false); setPickerSearch(''); } }}>
               <PickerContainer>
                 <PickerHeader>
-                  <h3>Send from</h3>
-                  <button aria-label="Close picker" onClick={() => { setShowAliasPicker(false); setPickerSearch(''); }}>
+                  <h3>{t('dashboard.sendFrom')}</h3>
+                  <button aria-label={t('dashboard.closePicker')} onClick={() => { setShowAliasPicker(false); setPickerSearch(''); }}>
                     <MdClose size={20} />
                   </button>
                 </PickerHeader>
                 <PickerSearchInput
-                  placeholder="Search addresses..."
+                  placeholder={t('dashboard.searchAddresses')}
                   value={pickerSearch}
                   onChange={(e) => setPickerSearch(e.target.value)}
                   autoFocus
@@ -413,7 +415,7 @@ export const Dashboard = () => {
                       {userData?.user.username}@duck.com
                       {!effectiveSender && <MdCheck size={14} style={{ marginLeft: 6, verticalAlign: 'middle' }} />}
                     </PickerItemText>
-                    <PickerItemLabel>Personal address</PickerItemLabel>
+                    <PickerItemLabel>{t('dashboard.personalAddress')}</PickerItemLabel>
                   </PickerItem>
                   {filteredPickerAddresses.map(addr => (
                     <PickerItem
@@ -434,7 +436,7 @@ export const Dashboard = () => {
           )}
           <ItemListSection
             items={reverseAliasItems}
-            config={SEND_LIST_CONFIG}
+            config={sendListConfig}
             copyToClipboard={copyToClipboard}
             formatTime={formatTime}
             onUpdateNotes={handleUpdateReverseAliasNotes}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import { DuckService } from '../services/DuckService'
 import { MdArrowBack } from 'react-icons/md'
 import { useApp } from '../context/AppContext'
 import { ConfirmDialog } from '../components/ConfirmDialog'
+import { Interpolate, useI18n } from '../i18n'
 import { BackButton, PrimaryButton } from '../styles/SharedStyles'
 import { LoginContainer, LoginMessage, DuckText, InputWrapper, LoginInput, Suffix, LoginErrorMessage, SignupSection, SignupLink } from '../styles/pages.styles'
 
@@ -19,6 +20,7 @@ export const Login = ({ onSubmit, isAddingAccount, onBack }: LoginProps) => {
   const [showSignupDialog, setShowSignupDialog] = useState(false)
   const duckService = useMemo(() => new DuckService(), [])
   const { accounts } = useApp()
+  const { t } = useI18n()
   const checkClosedRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   useEffect(() => {
@@ -83,7 +85,7 @@ export const Login = ({ onSubmit, isAddingAccount, onBack }: LoginProps) => {
 
     if (accounts.some(acc => acc.username === cleanUsername)) {
       setLoading(false)
-      setError('This account is already logged in')
+      setError(t('login.alreadyLoggedIn'))
       return
     }
 
@@ -108,14 +110,16 @@ export const Login = ({ onSubmit, isAddingAccount, onBack }: LoginProps) => {
       {isAddingAccount && onBack && (
         <BackButton onClick={onBack}>
           <MdArrowBack size={20} />
-          Back to Dashboard
+          {t('common.backToDashboard')}
         </BackButton>
       )}
-      <LoginMessage>Login to manage your <DuckText>@duck.com</DuckText> addresses</LoginMessage>
+      <LoginMessage>
+        <Interpolate text={t('login.message')} values={{ duck: <DuckText>@duck.com</DuckText> }} />
+      </LoginMessage>
       <InputWrapper>
         <LoginInput
           type="text"
-          placeholder="Enter duck username"
+          placeholder={t('login.placeholder')}
           value={username}
           onChange={handleUsernameChange}
           onKeyUp={handleKeyPress}
@@ -127,21 +131,21 @@ export const Login = ({ onSubmit, isAddingAccount, onBack }: LoginProps) => {
         <Suffix>@duck.com</Suffix>
       </InputWrapper>
       <PrimaryButton onClick={handleSubmit} disabled={!username || loading}>
-        {loading ? 'Sending...' : 'Continue'}
+        {loading ? t('login.sending') : t('login.continue')}
       </PrimaryButton>
       {error && <LoginErrorMessage>{error}</LoginErrorMessage>}
 
       <SignupSection>
-        Don't have one? <SignupLink onClick={handleCreateAccount}>Create now</SignupLink>
+        {t('login.noAccount')} <SignupLink onClick={handleCreateAccount}>{t('login.createNow')}</SignupLink>
       </SignupSection>
 
       <ConfirmDialog
         isOpen={showSignupDialog}
         variant="info"
-        title="Create a duck address"
-        message="You'll be redirected to DuckDuckGo to create your @duck.com address. Once you complete the signup, you'll be automatically logged in."
-        confirmLabel="Continue to DuckDuckGo"
-        cancelLabel="Cancel"
+        title={t('login.signupTitle')}
+        message={t('login.signupMessage')}
+        confirmLabel={t('login.signupConfirm')}
+        cancelLabel={t('common.cancel')}
         onConfirm={handleSignupConfirm}
         onCancel={() => setShowSignupDialog(false)}
       />

--- a/src/pages/MyAccount.tsx
+++ b/src/pages/MyAccount.tsx
@@ -5,6 +5,7 @@ import { DuckService } from '../services/DuckService'
 import { useNotification } from '../components/Notification'
 import { UserInfoSection } from '../components/UserInfoSection'
 import { ConfirmDialog } from '../components/ConfirmDialog'
+import { useI18n } from '../i18n'
 import { BackButton } from '../styles/SharedStyles'
 import { MyAccountContainer, ManageAccountButton, DeleteAccountButton } from '../styles/pages.styles'
 
@@ -15,6 +16,7 @@ interface MyAccountProps {
 export const MyAccount = ({ onBack }: MyAccountProps) => {
   const { userData, currentAccount, deleteCurrentAccount } = useApp()
   const { showNotification, NotificationRenderer } = useNotification()
+  const { t } = useI18n()
   const duckService = useMemo(() => new DuckService(), [])
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false)
   const [removing, setRemoving] = useState(false)
@@ -29,9 +31,9 @@ export const MyAccount = ({ onBack }: MyAccountProps) => {
   const copyToClipboard = useCallback(async (text: string, event?: MouseEvent) => {
     try {
       await navigator.clipboard.writeText(text)
-      showNotification('Copied!', event)
+      showNotification(t('common.copied'), event)
     } catch {
-      showNotification('Failed to copy', event)
+      showNotification(t('common.failedToCopy'), event)
     }
   }, [showNotification])
 
@@ -47,23 +49,26 @@ export const MyAccount = ({ onBack }: MyAccountProps) => {
     if (result.status === 'success') {
       onBack()
     } else {
-      showNotification(result.message || 'Failed to remove account')
+      showNotification(result.message || t('myAccount.removeFailed'))
     }
   }
 
   if (!userData) return null
 
-  const accountLabel = currentAccount ? `${currentAccount}@duck.com` : 'this account'
-  const addressText = `${counts.addresses} saved address${counts.addresses === 1 ? '' : 'es'}`
+  const accountLabel = currentAccount ? `${currentAccount}@duck.com` : t('myAccount.thisAccount')
+  const addressText = t('myAccount.savedAddresses', { count: counts.addresses })
   const removedParts = counts.aliases > 0
-    ? `${addressText} and ${counts.aliases} reverse alias${counts.aliases === 1 ? '' : 'es'}`
+    ? t('myAccount.addressesAndAliases', {
+        addresses: addressText,
+        aliases: t('myAccount.reverseAliases', { count: counts.aliases })
+      })
     : addressText
 
   return (
     <MyAccountContainer>
       <BackButton onClick={onBack}>
         <MdArrowBack size={20} />
-        Back
+        {t('common.back')}
       </BackButton>
 
       <UserInfoSection
@@ -74,22 +79,22 @@ export const MyAccount = ({ onBack }: MyAccountProps) => {
 
       <ManageAccountButton onClick={handleOpenDuckDuckGoEmail}>
         <MdOpenInNew size={20} />
-        Manage your duck account
+        {t('myAccount.manage')}
         <MdOpenInNew size={16} />
       </ManageAccountButton>
 
       <DeleteAccountButton onClick={() => setShowRemoveConfirm(true)} disabled={removing}>
         <MdDeleteOutline size={20} />
-        {removing ? 'Removing...' : 'Remove account local data'}
+        {removing ? t('myAccount.removing') : t('myAccount.remove')}
       </DeleteAccountButton>
 
       <ConfirmDialog
         isOpen={showRemoveConfirm}
         variant="warning"
-        title="Remove account local data"
-        message={`You're about to remove ${accountLabel} along with its ${removedParts} from this device and from sync. Your DuckDuckGo account itself is not affected. This cannot be undone.`}
-        confirmLabel="Remove"
-        cancelLabel="Cancel"
+        title={t('myAccount.removeTitle')}
+        message={t('myAccount.removeMessage', { account: accountLabel, data: removedParts })}
+        confirmLabel={t('common.delete')}
+        cancelLabel={t('common.cancel')}
         onConfirm={handleRemoveAccount}
         onCancel={() => setShowRemoveConfirm(false)}
       />

--- a/src/pages/OTP.tsx
+++ b/src/pages/OTP.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { DuckService } from '../services/DuckService'
 import { useApp } from '../context/AppContext'
 import { MdArrowBack, MdKeyboardArrowDown } from 'react-icons/md'
+import { useI18n } from '../i18n'
 import { BackButton } from '../styles/SharedStyles'
 import {
   OTPContainer, OTPUsername, OTPMessage, OTPInput, OTPButton,
@@ -25,6 +26,7 @@ export const OTP = ({ username, onBack, isAddingAccount, onSuccess }: OTPProps) 
   const [resendSuccess, setResendSuccess] = useState('')
   const [showHint, setShowHint] = useState(false)
   const { setUserData, switchAccount } = useApp()
+  const { t } = useI18n()
   const duckService = useMemo(() => new DuckService(), [])
   const cooldownRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const resendTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -67,12 +69,12 @@ export const OTP = ({ username, onBack, isAddingAccount, onSuccess }: OTPProps) 
 
     setResendLoading(false)
     if (response.status === 'success') {
-      setResendSuccess('A new passphrase has been sent to your email.')
+      setResendSuccess(t('otp.resendSuccess'))
       startCooldown()
       if (resendTimeoutRef.current) clearTimeout(resendTimeoutRef.current)
       resendTimeoutRef.current = setTimeout(() => setResendSuccess(''), 5000)
     } else {
-      setError(response.message || 'Failed to resend passphrase.')
+      setError(response.message || t('otp.resendFailed'))
     }
   }
 
@@ -97,11 +99,11 @@ export const OTP = ({ username, onBack, isAddingAccount, onSuccess }: OTPProps) 
               await chrome.storage.local.remove(['otp_verification_in_progress']);
             } catch (error) {
               console.error('Error switching account:', error);
-              setError('Failed to switch to new account');
+              setError(t('otp.switchFailed'));
               await chrome.storage.local.remove(['otp_verification_in_progress']);
             }
           } else {
-            setError('Failed to get user data');
+            setError(t('otp.userDataFailed'));
             await chrome.storage.local.remove(['otp_verification_in_progress']);
           }
         } else if (response.dashboard) {
@@ -112,11 +114,11 @@ export const OTP = ({ username, onBack, isAddingAccount, onSuccess }: OTPProps) 
           }
         }
       } else {
-        setError(response.message || 'Failed to verify OTP');
+        setError(response.message || t('otp.verifyFailed'));
         await chrome.storage.local.remove(['otp_verification_in_progress']);
       }
     } catch (error) {
-      setError('An error occurred. Please try again.');
+      setError(t('otp.genericError'));
       await chrome.storage.local.remove(['otp_verification_in_progress']);
     } finally {
       setLoading(false);
@@ -152,14 +154,14 @@ export const OTP = ({ username, onBack, isAddingAccount, onSuccess }: OTPProps) 
     <OTPContainer>
       <BackButton onClick={onBack}>
         <MdArrowBack size={20} />
-        {isAddingAccount ? 'Back to login' : 'Back'}
+        {isAddingAccount ? t('otp.backToLogin') : t('common.back')}
       </BackButton>
 
-      <OTPUsername>Logged in as {username}@duck.com</OTPUsername>
-      <OTPMessage>One-time passphrase sent to your email</OTPMessage>
+      <OTPUsername>{t('otp.loggedInAs', { username })}</OTPUsername>
+      <OTPMessage>{t('otp.message')}</OTPMessage>
       <OTPInput
         type="text"
-        placeholder="e.g. morality landless proved paprika"
+        placeholder={t('otp.placeholder')}
         value={otp}
         onChange={(e) => setOtp(e.target.value.toLowerCase())}
         onKeyUp={handleKeyPress}
@@ -173,12 +175,12 @@ export const OTP = ({ username, onBack, isAddingAccount, onSuccess }: OTPProps) 
         onClick={handleVerify}
         disabled={otp.split(' ').filter(Boolean).length !== 4 || loading}
       >
-        {loading ? 'Verifying...' : 'Verify OTP'}
+        {loading ? t('otp.verifying') : t('otp.verify')}
       </OTPButton>
 
       <OTPResendRow>
         <OTPResendButton onClick={handleResend} disabled={cooldown > 0 || resendLoading}>
-          {resendLoading ? 'Sending...' : 'Resend passphrase'}
+          {resendLoading ? t('login.sending') : t('otp.resend')}
         </OTPResendButton>
         {cooldown > 0 && <OTPCooldownText>({cooldown}s)</OTPCooldownText>}
       </OTPResendRow>
@@ -188,13 +190,10 @@ export const OTP = ({ username, onBack, isAddingAccount, onSuccess }: OTPProps) 
 
       <OTPHintToggle onClick={() => setShowHint(prev => !prev)}>
         <MdKeyboardArrowDown size={14} style={{ transform: showHint ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s' }} />
-        Having trouble logging in?
+        {t('otp.troubleToggle')}
       </OTPHintToggle>
       {showHint && (
-        <OTPHint>
-          Didn't receive it? Check your spam or junk folder. Some email providers
-          (like ProtonMail) may delay or filter messages from DuckDuckGo.
-        </OTPHint>
+        <OTPHint>{t('otp.hint')}</OTPHint>
       )}
     </OTPContainer>
   )

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,11 +1,12 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
-import { MdFileUpload, MdArrowBack, MdDescription, MdSecurity, MdDownload, MdSync, MdRefresh, MdKeyboardArrowDown, MdPalette, MdLightMode, MdDarkMode, MdDevices } from "react-icons/md";
+import { MdFileUpload, MdArrowBack, MdDescription, MdSecurity, MdDownload, MdSync, MdRefresh, MdKeyboardArrowDown, MdPalette, MdLightMode, MdDarkMode, MdDevices, MdTranslate } from "react-icons/md";
 import { DuckService } from "../services/DuckService";
 import { StorageService } from "../services/StorageService";
 import { SyncService, SyncOptions } from "../services/SyncService";
 import { ImportAddressesResult } from "../services/ImportExportService";
 import { usePermissions, PERMISSIONS, ALL_PERMISSIONS } from "../context/PermissionContext";
 import { useApp, ThemeMode } from "../context/AppContext";
+import { Language, TranslateParams, TranslationKey, useI18n } from "../i18n";
 import { BackupSummary, TimeFormat } from "../types";
 import { PermissionToggle } from "../components/PermissionToggle";
 import { ConfirmDialog } from "../components/ConfirmDialog";
@@ -44,32 +45,39 @@ const api = typeof browser !== 'undefined' ? browser : chrome;
 const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
 const isFirefoxPopup = isFirefox && !window.location.search.includes('popout=1');
 
-const describeAddressImport = (result: ImportAddressesResult): string => {
+type Translate = (key: TranslationKey, params?: TranslateParams) => string;
+
+const describeAddressImport = (result: ImportAddressesResult, t: Translate): string => {
   if (!result.success) {
-    return `Import failed: ${result.error || 'Unknown error'}`;
+    return t('settings.importFailedWithReason', { reason: result.error || t('common.unknownError') });
   }
 
   const notes: string[] = [];
   if (result.duplicates > 0) {
-    notes.push(`${result.duplicates} duplicate${result.duplicates === 1 ? '' : 's'} skipped`);
+    notes.push(t('settings.importDuplicates', { count: result.duplicates }));
   }
-  if (result.invalid > 0) notes.push(`${result.invalid} ignored (not a duck.com address)`);
+  if (result.invalid > 0) notes.push(t('settings.importInvalid', { count: result.invalid }));
 
   if (result.count === 0) {
-    return result.error || 'No new addresses to import.';
+    return result.error || t('settings.importNothingNew');
   }
 
-  const plural = result.count === 1 ? 'address' : 'addresses';
+  const imported = t('settings.importedCount', { count: result.count });
   return notes.length > 0
-    ? `Imported ${result.count} ${plural} — ${notes.join(', ')}`
-    : `Imported ${result.count} ${plural}`;
+    ? t('settings.importedCountWithNotes', { imported, notes: notes.join(', ') })
+    : imported;
 };
 
-const THEME_OPTIONS: Array<{ mode: ThemeMode; icon: typeof MdLightMode; label: string }> = [
-  { mode: 'light', icon: MdLightMode, label: 'Light' },
-  { mode: 'dark', icon: MdDarkMode, label: 'Dark' },
-  { mode: 'system', icon: MdDevices, label: 'System' },
+const THEME_OPTIONS: Array<{ mode: ThemeMode; icon: typeof MdLightMode; labelKey: TranslationKey }> = [
+  { mode: 'light', icon: MdLightMode, labelKey: 'settings.themeLight' },
+  { mode: 'dark', icon: MdDarkMode, labelKey: 'settings.themeDark' },
+  { mode: 'system', icon: MdDevices, labelKey: 'settings.themeSystem' },
 ];
+
+const LANGUAGE_LABEL_KEYS: Record<Language, TranslationKey> = {
+  en: 'language.en',
+  es: 'language.es',
+};
 
 interface SettingsProps {
   onBack?: () => void;
@@ -79,6 +87,16 @@ export const Settings = ({ onBack }: SettingsProps) => {
   const [importResult, setImportResult] = useState<string | null>(null);
   const { hasPermissions } = usePermissions();
   const { accounts, currentAccount, themeMode, setThemeMode } = useApp();
+  const { t, localeTag, language, languages, setLanguage } = useI18n();
+  const formatNumber = useCallback(
+    (value: number, digits: number) =>
+      value.toLocaleString(localeTag, { minimumFractionDigits: digits, maximumFractionDigits: digits }),
+    [localeTag]
+  );
+  const formatKb = useCallback(
+    (bytes: number, digits: number) => formatNumber(bytes / 1024, digits),
+    [formatNumber]
+  );
   const [permissionState, setPermissionState] = useState<Record<string, boolean>>({});
   const fileInputRef = useRef<HTMLInputElement>(null);
   const importingRef = useRef(false);
@@ -140,10 +158,10 @@ export const Settings = ({ onBack }: SettingsProps) => {
   };
 
   const getDropdownLabel = () => {
-    if (selectedAccounts.length === 0) return 'Select accounts...';
-    if (selectedAccounts.length === accounts.length) return 'All accounts';
+    if (selectedAccounts.length === 0) return t('settings.selectAccounts');
+    if (selectedAccounts.length === accounts.length) return t('settings.allAccounts');
     if (selectedAccounts.length === 1) return `${selectedAccounts[0]}@duck.com`;
-    return `${selectedAccounts.length} accounts selected`;
+    return t('settings.accountsSelected', { count: selectedAccounts.length });
   };
 
   useEffect(() => {
@@ -186,7 +204,7 @@ export const Settings = ({ onBack }: SettingsProps) => {
       if (message.action === 'syncAutoDisabled') {
         setSyncOptions(prev => ({ ...prev, enabled: false }));
         setSyncStats(null);
-        setImportResult('Sync was automatically disabled because storage quota was exceeded.');
+        setImportResult(t('settings.syncAutoDisabled'));
       }
     };
 
@@ -247,9 +265,9 @@ export const Settings = ({ onBack }: SettingsProps) => {
   };
 
   const getSyncAccountLabel = () => {
-    if (syncOptions.syncAccounts.length === 0) return 'All accounts';
+    if (syncOptions.syncAccounts.length === 0) return t('settings.allAccounts');
     if (syncOptions.syncAccounts.length === 1) return `${syncOptions.syncAccounts[0]}@duck.com`;
-    return `${syncOptions.syncAccounts.length} accounts selected`;
+    return t('settings.accountsSelected', { count: syncOptions.syncAccounts.length });
   };
 
   const isAccountSyncSelected = (username: string) => {
@@ -334,32 +352,32 @@ export const Settings = ({ onBack }: SettingsProps) => {
     const lines: string[] = [];
 
     if (s.action === 'export') {
-      lines.push(`Accounts: ${s.accounts.map(a => a.username + '@duck.com').join(', ')}`);
-      lines.push(`Addresses: ${s.totalAddresses}`);
-      lines.push(`Reverse aliases: ${s.totalReverseAliases}`);
-      if (s.includesSession) lines.push(`Session data: included`);
+      lines.push(t('settings.summaryAccounts', { accounts: s.accounts.map(a => a.username + '@duck.com').join(', ') }));
+      lines.push(t('settings.summaryAddresses', { count: s.totalAddresses }));
+      lines.push(t('settings.summaryReverseAliases', { count: s.totalReverseAliases }));
+      if (s.includesSession) lines.push(t('settings.summarySessionIncluded'));
     } else {
       if (s.newAccounts && s.newAccounts > 0) {
-        lines.push(`New accounts added: ${s.newAccounts}`);
+        lines.push(t('settings.summaryNewAccounts', { count: s.newAccounts }));
       }
       for (const a of s.accounts) {
         const parts: string[] = [];
-        if (a.addresses > 0) parts.push(`${a.addresses} addresses`);
-        if (a.reverseAliases > 0) parts.push(`${a.reverseAliases} reverse aliases`);
+        if (a.addresses > 0) parts.push(t('settings.summaryAddressCount', { count: a.addresses }));
+        if (a.reverseAliases > 0) parts.push(t('settings.summaryAliasCount', { count: a.reverseAliases }));
         if (parts.length > 0) {
-          lines.push(`${a.username}@duck.com: +${parts.join(', ')}`);
+          lines.push(t('settings.summaryAccountLine', { account: a.username, parts: parts.join(', ') }));
         }
       }
       if ((s.skippedAddresses || 0) > 0 || (s.skippedReverseAliases || 0) > 0) {
         const skipped: string[] = [];
-        if (s.skippedAddresses) skipped.push(`${s.skippedAddresses} addresses`);
-        if (s.skippedReverseAliases) skipped.push(`${s.skippedReverseAliases} reverse aliases`);
-        lines.push(`Skipped (already exist): ${skipped.join(', ')}`);
+        if (s.skippedAddresses) skipped.push(t('settings.summaryAddressCount', { count: s.skippedAddresses }));
+        if (s.skippedReverseAliases) skipped.push(t('settings.summaryAliasCount', { count: s.skippedReverseAliases }));
+        lines.push(t('settings.summarySkipped', { parts: skipped.join(', ') }));
       }
       if (s.newAddresses === 0 && s.newReverseAliases === 0 && (!s.newAccounts || s.newAccounts === 0)) {
-        lines.push('Everything was already up to date.');
+        lines.push(t('settings.summaryUpToDate'));
       }
-      if (s.includesSession) lines.push(`Session data: restored`);
+      if (s.includesSession) lines.push(t('settings.summarySessionRestored'));
     }
 
     return lines.join('\n');
@@ -398,7 +416,7 @@ export const Settings = ({ onBack }: SettingsProps) => {
       setBackupSummary(summary);
     } catch (error) {
       console.error("Failed to export backup:", error);
-      setImportResult("Failed to export backup");
+      setImportResult(t('settings.exportFailed'));
     } finally {
       setLoading(prev => ({ ...prev, export: false }));
     }
@@ -412,7 +430,7 @@ export const Settings = ({ onBack }: SettingsProps) => {
       const text = await file.text();
       await processImport(text);
     } catch (error) {
-      setImportResult("Import failed, invalid file");
+      setImportResult(t('settings.importFailedInvalidFile'));
     } finally {
       if (fileInputRef.current) {
         fileInputRef.current.value = '';
@@ -444,7 +462,7 @@ export const Settings = ({ onBack }: SettingsProps) => {
         if (result.success && result.summary) {
           setBackupSummary(result.summary);
         } else {
-          setImportResult(`Import failed: ${result.error || 'Unknown error'}`);
+          setImportResult(t('settings.importFailedWithReason', { reason: result.error || t('common.unknownError') }));
         }
         setLoading(prev => ({ ...prev, import: false }));
         return;
@@ -453,16 +471,16 @@ export const Settings = ({ onBack }: SettingsProps) => {
       if (parsed.addresses && Array.isArray(parsed.addresses)) {
         setLoading(prev => ({ ...prev, import: true }));
         const result = await duckService.importAddresses(text);
-        setImportResult(describeAddressImport(result));
+        setImportResult(describeAddressImport(result, t));
         setLoading(prev => ({ ...prev, import: false }));
         return;
       }
 
-      setImportResult("Unrecognized file format");
+      setImportResult(t('settings.unrecognizedFormat'));
     } catch {
       setLoading(prev => ({ ...prev, import: true }));
       const result = await duckService.importAddressList(text);
-      setImportResult(describeAddressImport(result));
+      setImportResult(describeAddressImport(result, t));
       setLoading(prev => ({ ...prev, import: false }));
     } finally {
       importingRef.current = false;
@@ -480,10 +498,10 @@ export const Settings = ({ onBack }: SettingsProps) => {
       if (result.success && result.summary) {
         setBackupSummary(result.summary);
       } else if (!result.success) {
-        setImportResult(`Import failed: ${result.error || 'Unknown error'}`);
+        setImportResult(t('settings.importFailedWithReason', { reason: result.error || t('common.unknownError') }));
       }
     } catch (error) {
-      setImportResult("Import failed");
+      setImportResult(t('settings.importFailed'));
     } finally {
       setPendingImportData(null);
       setLoading(prev => ({ ...prev, import: false }));
@@ -533,16 +551,16 @@ export const Settings = ({ onBack }: SettingsProps) => {
       {onBack && (
         <BackButton onClick={onBack}>
           <MdArrowBack size={20} />
-          Back to Dashboard
+          {t('common.backToDashboard')}
         </BackButton>
       )}
       <Section>
         <SectionHeader>
-          <h2><MdPalette size={20} style={{ marginRight: '8px' }} />Appearance</h2>
+          <h2><MdPalette size={20} style={{ marginRight: '8px' }} />{t('settings.appearance')}</h2>
         </SectionHeader>
-        <ThemeOptionLabel>Theme</ThemeOptionLabel>
+        <ThemeOptionLabel>{t('settings.theme')}</ThemeOptionLabel>
         <ThemeOptionGroup>
-          {THEME_OPTIONS.map(({ mode, icon: Icon, label }) => (
+          {THEME_OPTIONS.map(({ mode, icon: Icon, labelKey }) => (
             <ThemeOptionButton
               key={mode}
               type="button"
@@ -551,7 +569,25 @@ export const Settings = ({ onBack }: SettingsProps) => {
               onClick={() => setThemeMode(mode)}
             >
               <Icon size={16} />
-              {label}
+              {t(labelKey)}
+            </ThemeOptionButton>
+          ))}
+        </ThemeOptionGroup>
+        <ThemeOptionLabel>
+          <MdTranslate size={14} style={{ marginRight: '6px', verticalAlign: 'text-bottom' }} />
+          {t('settings.language')}
+        </ThemeOptionLabel>
+        <ThemeOptionGroup>
+          {languages.map(code => (
+            <ThemeOptionButton
+              key={code}
+              type="button"
+              active={language === code}
+              aria-pressed={language === code}
+              lang={code}
+              onClick={() => setLanguage(code)}
+            >
+              {t(LANGUAGE_LABEL_KEYS[code])}
             </ThemeOptionButton>
           ))}
         </ThemeOptionGroup>
@@ -564,19 +600,18 @@ export const Settings = ({ onBack }: SettingsProps) => {
             />
             <SyncToggleSlider />
           </SyncToggleSwitch>
-          24-hour time
+          {t('settings.timeFormat24h')}
         </SyncOptionRow>
       </Section>
 
       <Section>
         <SectionHeader>
-          <h2><MdSecurity size={20} style={{ marginRight: '8px' }} />Permissions & features</h2>
+          <h2><MdSecurity size={20} style={{ marginRight: '8px' }} />{t('settings.permissions')}</h2>
         </SectionHeader>
         {ALL_PERMISSIONS.map(permission => (
           <PermissionToggle
             key={permission}
-            name={PERMISSIONS[permission].name}
-            description={PERMISSIONS[permission].description}
+            permission={permission}
             isEnabled={permission === 'storage' || permission === 'contextMenu' ? true : permissionState[permission] || false}
             onChange={(enabled) => togglePermission(permission, enabled)}
             disabled={false}
@@ -588,7 +623,7 @@ export const Settings = ({ onBack }: SettingsProps) => {
         <SectionHeader>
           <h2>
             <MdSync size={20} style={{ marginRight: '8px' }} />
-            Sync
+            {t('settings.sync')}
           </h2>
           <SyncToggleSwitch>
             <SyncToggleInput
@@ -624,7 +659,7 @@ export const Settings = ({ onBack }: SettingsProps) => {
                         />
                         {account.username}@duck.com
                         {account.username === currentAccount && (
-                          <SyncOptionHint>(current)</SyncOptionHint>
+                          <SyncOptionHint>{t('common.current')}</SyncOptionHint>
                         )}
                       </DropdownItem>
                     ))}
@@ -634,7 +669,7 @@ export const Settings = ({ onBack }: SettingsProps) => {
             )}
 
             <SyncOptionsContainer>
-              <SyncOptionsTitle>Sync options</SyncOptionsTitle>
+              <SyncOptionsTitle>{t('settings.syncOptions')}</SyncOptionsTitle>
               <SyncOptionRow>
                 <SyncToggleSwitch>
                   <SyncToggleInput
@@ -644,7 +679,7 @@ export const Settings = ({ onBack }: SettingsProps) => {
                   />
                   <SyncToggleSlider />
                 </SyncToggleSwitch>
-                Addresses
+                {t('settings.syncAddresses')}
               </SyncOptionRow>
               <SyncOptionRow>
                 <SyncToggleSwitch>
@@ -655,7 +690,7 @@ export const Settings = ({ onBack }: SettingsProps) => {
                   />
                   <SyncToggleSlider />
                 </SyncToggleSwitch>
-                Reverse Aliases
+                {t('settings.syncReverseAliases')}
               </SyncOptionRow>
               <SyncOptionRow>
                 <SyncToggleSwitch>
@@ -666,14 +701,14 @@ export const Settings = ({ onBack }: SettingsProps) => {
                   />
                   <SyncToggleSlider />
                 </SyncToggleSwitch>
-                Session Data
-                <SyncOptionHint>(login data & settings)</SyncOptionHint>
+                {t('settings.syncSessionData')}
+                <SyncOptionHint>{t('settings.syncSessionHint')}</SyncOptionHint>
               </SyncOptionRow>
               {syncOptions.session && (
                 <div style={{ marginLeft: '56px', marginTop: '4px', fontSize: '12px', color: '#ff9f19' }}>
                   {isFirefox
-                    ? 'Session data includes your access tokens. They are encrypted by Firefox during sync but stored in your Mozilla account.'
-                    : 'Session data includes your access tokens. They are encrypted by Chrome during sync but stored in your Google account.'}
+                    ? t('settings.syncTokenWarningFirefox')
+                    : t('settings.syncTokenWarningChrome')}
                 </div>
               )}
             </SyncOptionsContainer>
@@ -682,13 +717,13 @@ export const Settings = ({ onBack }: SettingsProps) => {
               <SyncStatsContainer>
                 <SyncStatRow>
                   <div>
-                    <strong>Status:</strong> {syncStats.lastSync ? `Last synced ${new Date(syncStats.lastSync).toLocaleString()}` : 'Never synced'}
+                    <strong>{t('settings.syncStatus')}</strong> {syncStats.lastSync ? t('settings.syncLastSynced', { date: new Date(syncStats.lastSync).toLocaleString(localeTag) }) : t('settings.syncNever')}
                   </div>
                   <SyncStatValue>
                     <RefreshIconButton
                       onClick={handleRefreshSync}
                       disabled={loading.refreshSync}
-                      title="Refresh"
+                      title={t('settings.syncRefresh')}
                     >
                       <MdRefresh size={16} />
                     </RefreshIconButton>
@@ -696,7 +731,7 @@ export const Settings = ({ onBack }: SettingsProps) => {
                 </SyncStatRow>
                 <SyncStatRow>
                   <div>
-                    <strong>Storage used:</strong> {(syncStats.bytesInUse / 1024).toFixed(2)} KB / {(syncStats.quotaBytes / 1024).toFixed(0)} KB ({syncStats.percentUsed.toFixed(1)}%)
+                    <strong>{t('settings.syncStorageUsed')}</strong> {formatKb(syncStats.bytesInUse, 2)} KB / {formatKb(syncStats.quotaBytes, 0)} KB ({formatNumber(syncStats.percentUsed, 1)}%)
                   </div>
                 </SyncStatRow>
               </SyncStatsContainer>
@@ -707,7 +742,7 @@ export const Settings = ({ onBack }: SettingsProps) => {
 
       <Section>
         <SectionHeader>
-          <h2><MdDescription size={20} style={{ marginRight: '8px' }} />Backup & restore</h2>
+          <h2><MdDescription size={20} style={{ marginRight: '8px' }} />{t('settings.backup')}</h2>
         </SectionHeader>
 
         <ExportButtonsContainer>
@@ -716,24 +751,23 @@ export const Settings = ({ onBack }: SettingsProps) => {
             disabled={loading.export || selectedAccounts.length === 0}
           >
             <MdDownload size={20} />
-            {loading.export ? 'Exporting...' : 'Export backup'}
+            {loading.export ? t('settings.exporting') : t('settings.exportBackup')}
           </BackupButton>
           <BackupButton
             onClick={isFirefoxPopup ? () => setShowPopoutPrompt(true) : handleImportClick}
             disabled={loading.import}
           >
             <MdFileUpload size={20} />
-            {loading.import ? 'Importing...' : 'Import backup'}
+            {loading.import ? t('settings.importing') : t('settings.importBackup')}
           </BackupButton>
         </ExportButtonsContainer>
 
         <ExportOptionHint style={{ display: 'block', marginBottom: '16px' }}>
-          Import accepts a Qwacky backup (.json), or a plain .txt list of existing
-          duck.com addresses — one per line.
+          {t('settings.importHint')}
         </ExportOptionHint>
 
         <ExportOptionsContainer>
-          <ExportOptionsTitle>Export options</ExportOptionsTitle>
+          <ExportOptionsTitle>{t('settings.exportOptions')}</ExportOptionsTitle>
 
           {accounts.length > 1 && (
             <DropdownWrapper ref={dropdownRef}>
@@ -756,7 +790,7 @@ export const Settings = ({ onBack }: SettingsProps) => {
                       />
                       {account.username}@duck.com
                       {account.username === currentAccount && (
-                        <ExportOptionHint>(current)</ExportOptionHint>
+                        <ExportOptionHint>{t('common.current')}</ExportOptionHint>
                       )}
                     </DropdownItem>
                   ))}
@@ -774,8 +808,8 @@ export const Settings = ({ onBack }: SettingsProps) => {
               />
               <SyncToggleSlider />
             </SyncToggleSwitch>
-            Include session
-            <ExportOptionHint>(login data & settings)</ExportOptionHint>
+            {t('settings.includeSession')}
+            <ExportOptionHint>{t('settings.syncSessionHint')}</ExportOptionHint>
           </ExportOptionRow>
         </ExportOptionsContainer>
 
@@ -795,10 +829,10 @@ export const Settings = ({ onBack }: SettingsProps) => {
       <ConfirmDialog
         isOpen={showPopoutPrompt}
         variant="info"
-        title="Open in new window"
-        message="Firefox doesn't allow file selection from the popup. The extension will open in a new window where you can import your backup normally."
-        confirmLabel="Open window"
-        cancelLabel="Cancel"
+        title={t('settings.popoutTitle')}
+        message={t('settings.popoutMessage')}
+        confirmLabel={t('settings.popoutConfirm')}
+        cancelLabel={t('common.cancel')}
         onConfirm={() => {
           setShowPopoutPrompt(false);
           chrome.runtime.sendMessage({ action: 'popoutExtension' });
@@ -810,10 +844,10 @@ export const Settings = ({ onBack }: SettingsProps) => {
       <ConfirmDialog
         isOpen={showExportWarning}
         variant="warning"
-        title="Security warning"
-        message="The exported file will contain your access token and login credentials. Keep this file secure and do not share it. Anyone with this file can access your DuckDuckGo Email account."
-        confirmLabel="Export anyway"
-        cancelLabel="Cancel"
+        title={t('settings.exportWarningTitle')}
+        message={t('settings.exportWarningMessage')}
+        confirmLabel={t('settings.exportWarningConfirm')}
+        cancelLabel={t('common.cancel')}
         onConfirm={() => {
           setShowExportWarning(false);
           doExport();
@@ -824,10 +858,10 @@ export const Settings = ({ onBack }: SettingsProps) => {
       <ConfirmDialog
         isOpen={showImportConfirm}
         variant="warning"
-        title="Import backup"
-        message="This backup contains session data. Importing it will add the accounts and their data to your extension. Are you sure?"
-        confirmLabel="Import"
-        cancelLabel="Cancel"
+        title={t('settings.importConfirmTitle')}
+        message={t('settings.importConfirmMessage')}
+        confirmLabel={t('settings.importConfirmButton')}
+        cancelLabel={t('common.cancel')}
         onConfirm={handleImportConfirmed}
         onCancel={() => {
           setShowImportConfirm(false);
@@ -838,9 +872,9 @@ export const Settings = ({ onBack }: SettingsProps) => {
       <ConfirmDialog
         isOpen={backupSummary !== null}
         variant="info"
-        title={backupSummary?.action === 'export' ? 'Export complete' : 'Import complete'}
+        title={backupSummary?.action === 'export' ? t('settings.exportComplete') : t('settings.importComplete')}
         message={backupSummary ? buildSummaryMessage(backupSummary) : ''}
-        confirmLabel="Close"
+        confirmLabel={t('common.close')}
         singleButton
         onConfirm={async () => {
           const isImport = backupSummary?.action === 'import';

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -1,3 +1,5 @@
+import { t } from '../i18n/core'
+
 export class AuthService {
   private headers: Record<string, string>
 
@@ -16,17 +18,17 @@ export class AuthService {
         { headers: this.headers }
       )
       if (response.ok) {
-        return { status: 'success', needs_otp: true, message: 'OTP sent to your email!' }
+        return { status: 'success', needs_otp: true, message: t('error.otpSent') }
       }
       if (response.status === 429) {
-        return { status: 'error', message: 'Too many requests. Please wait a moment before trying again.' }
+        return { status: 'error', message: t('error.tooManyRequests') }
       }
-      return { status: 'error', message: 'Failed to send OTP. Please try again later.' }
+      return { status: 'error', message: t('error.otpSendFailed') }
     } catch (error) {
       if (error instanceof TypeError && error.message === 'Failed to fetch') {
-        return { status: 'error', message: 'Network error. Please check your internet connection.' }
+        return { status: 'error', message: t('error.network') }
       }
-      return { status: 'error', message: error instanceof Error ? error.message : 'Unknown error' }
+      return { status: 'error', message: error instanceof Error ? error.message : t('common.unknownError') }
     }
   }
 
@@ -40,17 +42,17 @@ export class AuthService {
         { headers: this.headers }
       )
       if (loginResponse.status === 429) {
-        return { status: 'error', message: 'Too many requests. Please wait a moment before trying again.' }
+        return { status: 'error', message: t('error.tooManyRequests') }
       }
       if (!loginResponse.ok) {
-        return { status: 'error', message: 'Login failed. Please try again.' }
+        return { status: 'error', message: t('error.loginFailed') }
       }
 
       let loginData;
       try {
         loginData = await loginResponse.json();
       } catch {
-        return { status: 'error', message: 'Invalid response from server.' };
+        return { status: 'error', message: t('error.invalidServerResponse') };
       }
 
       if ('token' in loginData) {
@@ -61,30 +63,30 @@ export class AuthService {
         )
 
         if (!dashboardResponse.ok) {
-          return { status: 'error', message: 'Failed to load dashboard data.' }
+          return { status: 'error', message: t('error.dashboardFailed') }
         }
 
         let dashboardData;
         try {
           dashboardData = await dashboardResponse.json();
         } catch {
-          return { status: 'error', message: 'Invalid response from server.' };
+          return { status: 'error', message: t('error.invalidServerResponse') };
         }
 
         return {
           status: 'success',
           dashboard: dashboardData,
           access_token: loginData.token,
-          message: 'Login successful!'
+          message: t('error.loginSuccessful')
         }
       }
       
-      return { status: 'error', message: 'Invalid passphrase. Please check the passphrase in your email and try again.' }
+      return { status: 'error', message: t('error.invalidPassphrase') }
     } catch (error) {
       if (error instanceof TypeError && error.message === 'Failed to fetch') {
-        return { status: 'error', message: 'Network error. Please check your internet connection.' }
+        return { status: 'error', message: t('error.network') }
       }
-      return { status: 'error', message: error instanceof Error ? error.message : 'Unknown error' }
+      return { status: 'error', message: error instanceof Error ? error.message : t('common.unknownError') }
     }
   }
 
@@ -105,14 +107,14 @@ export class AuthService {
       )
       
       if (!response.ok) {
-        throw new Error('Failed to generate address')
+        throw new Error(t('error.generateFailed'))
       }
       
       let data;
       try {
         data = await response.json();
       } catch {
-        return { status: 'error', message: 'Invalid response from server.' };
+        return { status: 'error', message: t('error.invalidServerResponse') };
       }
       if (data.address) {
         return { 
@@ -120,11 +122,11 @@ export class AuthService {
           address: data.address 
         }
       }
-      throw new Error('Invalid response format')
+      throw new Error(t('error.invalidResponseFormat'))
     } catch (error) {
       return { 
         status: 'error', 
-        message: error instanceof Error ? error.message : 'Unknown error' 
+        message: error instanceof Error ? error.message : t('common.unknownError') 
       }
     }
   }

--- a/src/services/DuckService.ts
+++ b/src/services/DuckService.ts
@@ -2,6 +2,7 @@ import { AuthService } from './AuthService'
 import { StorageService } from './StorageService'
 import { ImportExportService, ImportAddressesResult } from './ImportExportService'
 import { LoginResponse, VerifyResponse, GenerateResponse, UserData, ReverseAlias } from '../types'
+import { t } from '../i18n/core'
 
 export class DuckService {
   private auth: AuthService
@@ -17,7 +18,7 @@ export class DuckService {
   async login(username: string): Promise<LoginResponse> {
     try {
       if (!username || typeof username !== 'string' || username.trim() === '') {
-        return { status: 'error', message: 'Username is required' }
+        return { status: 'error', message: t('error.usernameRequired') }
       }
       
       const response = await this.auth.requestOTP(username)
@@ -26,7 +27,7 @@ export class DuckService {
       console.error('Login error:', error)
       return { 
         status: 'error', 
-        message: error instanceof Error ? error.message : 'An unexpected error occurred during login' 
+        message: error instanceof Error ? error.message : t('error.unexpectedLogin') 
       }
     }
   }
@@ -34,11 +35,11 @@ export class DuckService {
   async verifyOTP(username: string, otp: string): Promise<VerifyResponse> {
     try {
       if (!username || typeof username !== 'string' || username.trim() === '') {
-        return { status: 'error', message: 'Username is required' }
+        return { status: 'error', message: t('error.usernameRequired') }
       }
       
       if (!otp || typeof otp !== 'string' || otp.trim() === '') {
-        return { status: 'error', message: 'OTP is required' }
+        return { status: 'error', message: t('error.otpRequired') }
       }
       
       const response = await this.auth.verifyOTP(username, otp)
@@ -55,7 +56,7 @@ export class DuckService {
       console.error('OTP verification error:', error)
       return { 
         status: 'error', 
-        message: error instanceof Error ? error.message : 'An unexpected error occurred during verification' 
+        message: error instanceof Error ? error.message : t('error.unexpectedVerify') 
       }
     }
   }
@@ -64,17 +65,17 @@ export class DuckService {
     try {
       const userData = await this.storage.getUserData()
       if (!userData) {
-        return { status: 'error', message: 'You need to login first' }
+        return { status: 'error', message: t('error.notAuthenticated') }
       }
       
       if (!userData.user || !userData.user.access_token) {
-        return { status: 'error', message: 'Invalid user data. Please log in again.' }
+        return { status: 'error', message: t('error.invalidUserData') }
       }
       
       const response = await this.auth.generateAddress(userData.user.access_token)
       if (response.status === 'success') {
         if (!response.address) {
-          return { status: 'error', message: 'No address returned from the server' }
+          return { status: 'error', message: t('error.noAddressReturned') }
         }
         
         await this.storage.saveGeneratedAddress(response.address, notes)
@@ -89,7 +90,7 @@ export class DuckService {
       console.error('Error generating address:', error)
       return { 
         status: 'error', 
-        message: error instanceof Error ? error.message : 'Unknown error generating address'
+        message: error instanceof Error ? error.message : t('error.unknownGenerate')
       }
     }
   }
@@ -108,7 +109,7 @@ export class DuckService {
       return await this.storage.deleteAccount(username)
     } catch (error: unknown) {
       console.error('Error deleting account:', error)
-      return { status: 'error', message: error instanceof Error ? error.message : 'Unknown error deleting account' }
+      return { status: 'error', message: error instanceof Error ? error.message : t('error.unknownDeleteAccount') }
     }
   }
 
@@ -120,7 +121,7 @@ export class DuckService {
       console.error('Error during logout:', error)
       return { 
         success: false, 
-        message: error instanceof Error ? error.message : 'Unknown error during logout'
+        message: error instanceof Error ? error.message : t('error.unknownLogout')
       }
     }
   }
@@ -195,7 +196,7 @@ export class DuckService {
         count: 0,
         duplicates: 0,
         invalid: 0,
-        error: error instanceof Error ? error.message : 'Unknown error importing addresses'
+        error: error instanceof Error ? error.message : t('error.unknownImportAddresses')
       }
     }
   }
@@ -210,7 +211,7 @@ export class DuckService {
         count: 0,
         duplicates: 0,
         invalid: 0,
-        error: error instanceof Error ? error.message : 'Unknown error importing addresses'
+        error: error instanceof Error ? error.message : t('error.unknownImportAddresses')
       }
     }
   }
@@ -279,7 +280,7 @@ export class DuckService {
       return await this.importExport.exportBackup(selectedAccounts, includeSession)
     } catch (error: unknown) {
       console.error('Error exporting backup:', error)
-      throw new Error(error instanceof Error ? error.message : 'Failed to export backup')
+      throw new Error(error instanceof Error ? error.message : t('error.exportBackupFailed'))
     }
   }
 
@@ -291,7 +292,7 @@ export class DuckService {
       return {
         success: false,
         hasSession: false,
-        error: error instanceof Error ? error.message : 'Unknown error importing backup'
+        error: error instanceof Error ? error.message : t('error.unknownImportBackup')
       }
     }
   }

--- a/src/services/ImportExportService.ts
+++ b/src/services/ImportExportService.ts
@@ -1,5 +1,6 @@
 import { StorageService } from './StorageService';
 import { QwackyBackup, BackupSummary } from '../types';
+import { t } from '../i18n/core';
 
 interface Address {
   value: string;
@@ -44,18 +45,18 @@ export class ImportExportService {
 
   async importAddresses(data: string): Promise<ImportAddressesResult> {
     if (!data || typeof data !== 'string' || data.trim() === '') {
-      return { success: false, count: 0, duplicates: 0, invalid: 0, error: 'Import data is empty or invalid' };
+      return { success: false, count: 0, duplicates: 0, invalid: 0, error: t('error.importDataEmpty') };
     }
 
     let records: Array<{ value?: string; timestamp?: number; notes?: string; tags?: string[] }>;
     try {
       const importData = JSON.parse(data);
       if (!importData.addresses || !Array.isArray(importData.addresses)) {
-        return { success: false, count: 0, duplicates: 0, invalid: 0, error: 'Invalid format: missing addresses array' };
+        return { success: false, count: 0, duplicates: 0, invalid: 0, error: t('error.importMissingAddresses') };
       }
       records = importData.addresses;
     } catch {
-      return { success: false, count: 0, duplicates: 0, invalid: 0, error: 'Invalid JSON format' };
+      return { success: false, count: 0, duplicates: 0, invalid: 0, error: t('error.importInvalidJson') };
     }
 
     return this.importAddressRecords(records);
@@ -63,7 +64,7 @@ export class ImportExportService {
 
   async importAddressList(text: string): Promise<ImportAddressesResult> {
     if (!text || typeof text !== 'string' || text.trim() === '') {
-      return { success: false, count: 0, duplicates: 0, invalid: 0, error: 'Import data is empty or invalid' };
+      return { success: false, count: 0, duplicates: 0, invalid: 0, error: t('error.importDataEmpty') };
     }
 
     const records = text
@@ -73,7 +74,7 @@ export class ImportExportService {
       .map(value => ({ value }));
 
     if (records.length === 0) {
-      return { success: false, count: 0, duplicates: 0, invalid: 0, error: 'No addresses found in file' };
+      return { success: false, count: 0, duplicates: 0, invalid: 0, error: t('error.importNoAddresses') };
     }
 
     return this.importAddressRecords(records);
@@ -110,7 +111,7 @@ export class ImportExportService {
 
       const userData = await this.storage.getUserData();
       if (!userData || !userData.user || !userData.user.username) {
-        return { success: false, count: 0, duplicates: inFileDuplicates, invalid, error: 'User data not found. Please log in again.' };
+        return { success: false, count: 0, duplicates: inFileDuplicates, invalid, error: t('error.userDataNotFoundLogin') };
       }
       const username = userData.user.username;
 
@@ -132,8 +133,8 @@ export class ImportExportService {
             duplicates,
             invalid,
             error: invalid > 0 && duplicates === 0
-              ? 'No valid duck.com addresses found.'
-              : 'No new addresses to import. All addresses already exist.'
+              ? t('error.importNoValidAddresses')
+              : t('error.importAllExist')
           };
         }
 
@@ -165,7 +166,7 @@ export class ImportExportService {
           count: 0,
           duplicates: inFileDuplicates,
           invalid,
-          error: `Storage error: ${storageError instanceof Error ? storageError.message : 'Failed to save imported addresses'}`
+          error: t('error.importStorage', { reason: storageError instanceof Error ? storageError.message : t('error.importSaveFailed') })
         };
       }
     } catch (error) {
@@ -175,7 +176,7 @@ export class ImportExportService {
         count: 0,
         duplicates: 0,
         invalid: 0,
-        error: `Import failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+        error: t('settings.importFailedWithReason', { reason: error instanceof Error ? error.message : t('common.unknownError') })
       };
     }
   }
@@ -276,29 +277,29 @@ export class ImportExportService {
       return { data: JSON.stringify(exportData, null, 2), summary };
     } catch (error) {
       console.error('Error exporting backup:', error);
-      throw new Error('Failed to export backup');
+      throw new Error(t('error.exportBackupFailed'));
     }
   }
 
   async importBackup(data: string): Promise<{ success: boolean; hasSession: boolean; summary?: BackupSummary; error?: string }> {
     try {
       if (!data || typeof data !== 'string' || data.trim() === '') {
-        return { success: false, hasSession: false, error: 'Import data is empty or invalid' };
+        return { success: false, hasSession: false, error: t('error.importDataEmpty') };
       }
 
       let backupData: QwackyBackup;
       try {
         backupData = JSON.parse(data);
       } catch {
-        return { success: false, hasSession: false, error: 'Invalid JSON format' };
+        return { success: false, hasSession: false, error: t('error.importInvalidJson') };
       }
 
       if (!backupData || typeof backupData !== 'object' || !backupData.version || !backupData.timestamp) {
-        return { success: false, hasSession: false, error: 'Invalid backup file format' };
+        return { success: false, hasSession: false, error: t('error.invalidBackupFormat') };
       }
 
       if (backupData.type !== 'qwacky_backup') {
-        return { success: false, hasSession: false, error: 'Not a valid Qwacky backup file' };
+        return { success: false, hasSession: false, error: t('error.notQwackyBackup') };
       }
 
       if (backupData.session) {
@@ -379,7 +380,7 @@ export class ImportExportService {
         } else {
           const currentAcct = session.accounts.find(a => a.username === session.currentAccount);
           if (!currentAcct) {
-            return { success: false, hasSession: false, error: 'Current account not found in session data' };
+            return { success: false, hasSession: false, error: t('error.accountNotInSession') };
           }
           await chrome.storage.local.set({
             user_data: currentAcct.userData,
@@ -419,7 +420,7 @@ export class ImportExportService {
 
       const userData = await this.storage.getUserData();
       if (!userData || !userData.user || !userData.user.username) {
-        return { success: false, hasSession: false, error: 'User data not found. Please log in first.' };
+        return { success: false, hasSession: false, error: t('error.userDataNotFoundLoginFirst') };
       }
       const username = userData.user.username;
 
@@ -498,7 +499,7 @@ export class ImportExportService {
       return {
         success: false,
         hasSession: false,
-        error: `Import failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+        error: t('settings.importFailedWithReason', { reason: error instanceof Error ? error.message : t('common.unknownError') })
       };
     }
   }

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -1,5 +1,6 @@
 import { UserData, ReverseAlias, TimeFormat } from '../types';
 import { SyncService } from './SyncService';
+import { t } from '../i18n/core';
 
 interface Address {
   value: string;
@@ -373,7 +374,7 @@ export class StorageService {
   async deleteAccount(username: string): Promise<{ status: 'success' | 'error'; loggedOut?: boolean; message?: string }> {
     try {
       if (!username) {
-        return { status: 'error', message: 'Username is required' };
+        return { status: 'error', message: t('error.usernameRequired') };
       }
 
       const result = await chrome.storage.local.get(['accounts', 'currentAccount', 'generated_addresses']);
@@ -414,7 +415,7 @@ export class StorageService {
 
       return { status: 'success', loggedOut };
     } catch (error) {
-      return { status: 'error', message: error instanceof Error ? error.message : 'Failed to delete account' };
+      return { status: 'error', message: error instanceof Error ? error.message : t('error.deleteAccountFailed') };
     }
   }
 

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -1,5 +1,6 @@
 import { errorMessage } from '../utils/safeOps';
 import { UserData, TimeFormat } from '../types';
+import { t } from '../i18n/core';
 
 interface Address {
   value: string;
@@ -278,7 +279,7 @@ export class SyncService {
       return await this.migrateToSync();
     }
 
-    return { success: true, message: 'Sync disabled' };
+    return { success: true, message: t('sync.disabled') };
   }
 
   private async migrateDataToSync(localData: any[], syncKey: string, mergeFn: (local: any[], sync: any[]) => Promise<any[]>, validateFn: (data: any[]) => any[]): Promise<{ count: number; error?: string }> {
@@ -308,7 +309,7 @@ export class SyncService {
 
     const dataSize = new Blob([finalData]).size;
     if (dataSize > 8000) {
-      return { count: 0, error: `Data too large (${Math.round(dataSize / 1024)}KB). Maximum is 8KB per account.` };
+      return { count: 0, error: t('sync.dataTooLarge', { size: Math.round(dataSize / 1024) }) };
     }
 
     await chrome.storage.sync.set({
@@ -324,7 +325,7 @@ export class SyncService {
     try {
       const username = await this.getCurrentUsername();
       if (!username) {
-        return { success: false, message: 'No user logged in' };
+        return { success: false, message: t('sync.noUser') };
       }
 
       const options = await this.getSyncOptions();
@@ -342,7 +343,7 @@ export class SyncService {
             (d: any[]) => this.validateAddresses(d)
           );
           if (result.error) return { success: false, message: result.error };
-          parts.push(`${result.count} addresses`);
+          parts.push(t('sync.addressCount', { count: result.count }));
         }
 
         const localData = await chrome.storage.local.get('user_data');
@@ -363,23 +364,23 @@ export class SyncService {
             (d: any[]) => this.validateReverseAliases(d)
           );
           if (result.error) return { success: false, message: result.error };
-          parts.push(`${result.count} reverse aliases`);
+          parts.push(t('sync.aliasCount', { count: result.count }));
         }
       }
 
       if (options.session) {
         await this.saveSessionToSync();
-        parts.push('session data');
+        parts.push(t('sync.sessionData'));
       }
 
       if (parts.length === 0) {
         await chrome.storage.sync.set({ [SyncService.SYNC_LAST_SYNC_KEY]: Date.now() });
-        return { success: true, message: 'No data to migrate' };
+        return { success: true, message: t('sync.nothingToMigrate') };
       }
 
       return {
         success: true,
-        message: `Successfully synced ${parts.join(', ')}`,
+        message: t('sync.syncedParts', { parts: parts.join(', ') }),
       };
     } catch (error: unknown) {
       console.error('Migration error:', error);
@@ -387,13 +388,13 @@ export class SyncService {
       if (errorMessage(error).includes('QUOTA_BYTES')) {
         return {
           success: false,
-          message: 'Storage quota exceeded. Try reducing the amount of synced data.',
+          message: t('sync.quotaExceeded'),
         };
       }
 
       return {
         success: false,
-        message: errorMessage(error) || 'Migration failed',
+        message: errorMessage(error) || t('sync.migrationFailed'),
       };
     }
   }
@@ -483,7 +484,7 @@ export class SyncService {
       if (errorMessage(error).includes('QUOTA_BYTES')) {
         await this.setSyncEnabled(false);
         chrome.runtime.sendMessage({ action: 'syncAutoDisabled', reason: 'quota_exceeded' }).catch(() => {});
-        throw new Error('Sync quota exceeded. Sync has been disabled.');
+        throw new Error(t('sync.quotaExceededDisabled'));
       }
 
       throw error;
@@ -926,13 +927,13 @@ export class SyncService {
   async pullFromSync(): Promise<{ success: boolean; message: string }> {
     const options = await this.getSyncOptions();
     if (!options.enabled) {
-      return { success: false, message: 'Sync is not enabled' };
+      return { success: false, message: t('sync.notEnabled') };
     }
 
     try {
       const username = await this.getCurrentUsername();
       if (!username) {
-        return { success: false, message: 'No user logged in' };
+        return { success: false, message: t('sync.noUser') };
       }
 
       const parts: string[] = [];
@@ -982,7 +983,7 @@ export class SyncService {
             if (!msg.includes('Receiving end does not exist')) console.error('Message send failed:', msg);
           });
 
-          parts.push(`${mergedAddresses.length} addresses`);
+          parts.push(t('sync.addressCount', { count: mergedAddresses.length }));
         }
       }
 
@@ -1011,7 +1012,7 @@ export class SyncService {
             if (!msg.includes('Receiving end does not exist')) console.error('Message send failed:', msg);
           });
 
-          parts.push(`${mergedAliases.length} reverse aliases`);
+          parts.push(t('sync.aliasCount', { count: mergedAliases.length }));
         }
       }
 
@@ -1030,19 +1031,19 @@ export class SyncService {
               sessionData,
             }).catch(() => {});
           }
-          parts.push('session data');
+          parts.push(t('sync.sessionData'));
         }
       }
 
       return {
         success: true,
-        message: parts.length > 0 ? `Successfully synced ${parts.join(', ')}` : 'No synced data found',
+        message: parts.length > 0 ? t('sync.syncedParts', { parts: parts.join(', ') }) : t('sync.noSyncedData'),
       };
     } catch (error: unknown) {
       console.error('Pull from sync error:', error);
       return {
         success: false,
-        message: errorMessage(error) || 'Failed to pull from sync',
+        message: errorMessage(error) || t('sync.pullFailed'),
       };
     }
   }

--- a/src/utils/safeOps.ts
+++ b/src/utils/safeOps.ts
@@ -1,7 +1,9 @@
+import { t } from '../i18n/core';
+
 export function errorMessage(err: unknown): string {
   if (err instanceof Error) return err.message;
   if (typeof err === 'string') return err;
-  return 'Unknown error';
+  return t('common.unknownError');
 }
 
 export async function safeSendTabMessage(api: typeof chrome, tabId: number, message: Record<string, unknown>): Promise<void> {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
-import { copyFileSync, mkdirSync, existsSync, readFileSync, writeFileSync } from 'fs'
+import { copyFileSync, mkdirSync, existsSync, readdirSync, readFileSync, writeFileSync } from 'fs'
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
@@ -27,6 +27,11 @@ const copyManifest = () => {
       })
 
       copyFileSync('assets/icons/qwacky.png', `${outDir}/assets/icons/qwacky.png`)
+
+      readdirSync('_locales').forEach(locale => {
+        mkdirSync(`${outDir}/_locales/${locale}`, { recursive: true })
+        copyFileSync(`_locales/${locale}/messages.json`, `${outDir}/_locales/${locale}/messages.json`)
+      })
 
       const polyfillPath = 'node_modules/webextension-polyfill/dist/browser-polyfill.js'
       if (existsSync(polyfillPath)) {


### PR DESCRIPTION
hi, been using Qwacky for a while now and it's genuinely great, thanks for making it. Wanted to give something back, so here's Spanish support.

Language gets picked from the browser on first run and you can change it in Settings > Appearance > Language. It swaps live, no reinstall.

All of it lives in `src/i18n`. English sits in `locales/en.ts` and is the source of truth, `es.ts` is typed against it so a missing key fails the build. 331 strings, all covered.

Four things weren't just text swaps:

* `PermissionToggle` found the right permission by matching its English name, so it takes an id now
* context menu titles are fixed when the menu is created, so background.ts rebuilds it on language change
* contentScript is injected as a classic script and can't import the locale files, so background sends it the strings
* dates and the sync KB figures were hardcoded to en-US

`tsc` is clean, both builds pass, and I checked the built contentScript.js is still import free. Haven't clicked through it in a browser though, so probably worth a look before merging.

Spanish is neutral rather than region specific. Happy to reword anything or restructure it if you'd rather it looked different.
