### PR TITLE
Show a spinner while the shortcut generates an address

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -405,6 +405,24 @@ api.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   return false
 })
 
+const GENERATING_MESSAGE = 'Generating duck address...'
+
+/**
+ * Generating an address needs a network round trip that can take a few
+ * seconds. Put the content script and a spinner on the page before waiting on
+ * it, otherwise the shortcut looks like it did nothing at all.
+ */
+const showPending = async (tabId: number, message: string): Promise<void> => {
+  try {
+    await api.scripting.executeScript({
+      target: { tabId },
+      files: ['contentScript.js']
+    })
+    await api.tabs.sendMessage(tabId, { type: 'show-pending', message })
+  } catch {
+  }
+}
+
 const performConvert = async (tabId: number, selectionText: string) => {
   try {
     await api.scripting.executeScript({
@@ -467,7 +485,10 @@ if (api.contextMenus) {
           } catch {}
         }
 
-        const response = await duckService.generateAddress(domain || undefined)
+        const pending = duckService.generateAddress(domain || undefined)
+        await showPending(tab.id, GENERATING_MESSAGE)
+        const response = await pending
+
         if (response.status === 'error') {
           try {
             await api.tabs.sendMessage(tab.id, {
@@ -478,11 +499,6 @@ if (api.contextMenus) {
           }
           return
         }
-
-        await api.scripting.executeScript({
-          target: { tabId: tab.id },
-          files: ['contentScript.js']
-        })
 
         try {
           await api.tabs.sendMessage(tab.id, {
@@ -542,7 +558,10 @@ if (api.commands) {
         } catch {}
       }
 
-      const response = await duckService.generateAddress(domain || undefined)
+      const pending = duckService.generateAddress(domain || undefined)
+      await showPending(activeTab.id, GENERATING_MESSAGE)
+      const response = await pending
+
       if (response.status === 'error') {
         try {
           await api.tabs.sendMessage(activeTab.id, {
@@ -553,11 +572,6 @@ if (api.commands) {
         }
         return
       }
-
-      await api.scripting.executeScript({
-        target: { tabId: activeTab.id },
-        files: ['contentScript.js']
-      })
 
       try {
         await api.tabs.sendMessage(activeTab.id, {

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -12,7 +12,47 @@ const setupConnection = () => {
   }
 }
 
-const showNotification = (message: string) => {
+// Only one notification is on screen at a time, so a result can replace the
+// pending spinner instead of stacking underneath it.
+let activeNotification: HTMLElement | null = null
+let dismissTimer: ReturnType<typeof setTimeout> | null = null
+
+const dismissNotification = () => {
+  if (dismissTimer) {
+    clearTimeout(dismissTimer)
+    dismissTimer = null
+  }
+  activeNotification?.remove()
+  activeNotification = null
+}
+
+const createSpinner = () => {
+  const spinner = document.createElement('span')
+  Object.assign(spinner.style, {
+    width: '14px',
+    height: '14px',
+    flex: '0 0 auto',
+    borderRadius: '50%',
+    boxSizing: 'border-box',
+    border: '2px solid rgba(255, 255, 255, 0.35)',
+    borderTopColor: '#fff'
+  })
+  // Animated here rather than with a stylesheet so nothing leaks into the page.
+  spinner.animate(
+    [{ transform: 'rotate(0deg)' }, { transform: 'rotate(360deg)' }],
+    { duration: 700, iterations: Infinity }
+  )
+  return spinner
+}
+
+// A pending notification waits for its result, but never hangs around forever
+// if the background page dies before sending one.
+const PENDING_TIMEOUT_MS = 20000
+const DISMISS_TIMEOUT_MS = 3000
+
+const showNotification = (message: string, pending = false) => {
+  dismissNotification()
+
   const notification = document.createElement('div')
   const styles = {
     position: 'fixed',
@@ -24,17 +64,30 @@ const showNotification = (message: string) => {
     padding: '16px 24px',
     borderRadius: '8px',
     zIndex: '999999',
-    boxShadow: '0 4px 8px rgba(0, 0, 0, 0.2)'
+    boxShadow: '0 4px 8px rgba(0, 0, 0, 0.2)',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '10px'
   }
   Object.assign(notification.style, styles)
   notification.setAttribute('role', 'status')
   notification.setAttribute('aria-live', 'polite')
-  notification.textContent = message === 'Not authenticated' ? 'You need to login first' : message
+
+  if (pending) {
+    notification.appendChild(createSpinner())
+  }
+
+  const label = document.createElement('span')
+  label.textContent = message === 'Not authenticated' ? 'You need to login first' : message
+  notification.appendChild(label)
+
   document.body.appendChild(notification)
-  
-  setTimeout(() => {
-    notification.remove()
-  }, 3000)
+  activeNotification = notification
+
+  dismissTimer = setTimeout(
+    dismissNotification,
+    pending ? PENDING_TIMEOUT_MS : DISMISS_TIMEOUT_MS
+  )
 }
 
 const fillInput = (element: HTMLElement | null, value: string) => {
@@ -139,6 +192,10 @@ if (!(window as unknown as { __qwackyContentScript?: boolean }).__qwackyContentS
           ? 'Converted and copied to clipboard'
           : 'Converted, but could not copy to clipboard. Please check permissions in settings.');
       }
+    }
+
+    if (message.type === 'show-pending') {
+      showNotification(message.message, true)
     }
 
     if (message.type === 'show-notification') {


### PR DESCRIPTION
hi, this is for #20.

Had a look and the reason nothing shows up is that the content script only gets injected *after* `generateAddress()` comes back. So for the whole length of the network call there's genuinely nothing on the page that could draw anything, which is why the shortcut feels like it didn't register.

Fix is to kick off the request first, then inject and put a spinner up while it's in flight:

```ts
const pending = duckService.generateAddress(domain || undefined)
await showPending(activeTab.id, GENERATING_MESSAGE)
const response = await pending
```

Starting the request before the injection means the spinner doesn't add any delay to the actual call. The result then replaces that same notification rather than stacking a second one on top, so contentScript now keeps track of the notification that's currently up.

While I was in there I noticed the error path sends `show-notification` without injecting the content script first, so a failed generate usually showed nothing at all. Injecting up front fixes that as a side effect.

Same change applies to the context menu item since it goes through the same code.

Small details:

* spinner is animated with `element.animate()` instead of a stylesheet, so nothing gets injected into the page's CSS
* the pending notification has a 20s cap so it can't get stuck on screen if background dies before sending a result
* normal notifications still dismiss after 3s like before

### Testing

Ran the built `dist_chrome/contentScript.js` on a page and drove it through its message listener:

* spinner shows on `show-pending` and is still up after 3.6s (the old code killed every notification at 3s)
* `fill-address` replaces it in place, one notification on screen not two, spinner gone, input filled with `abc123@duck.com`
* result still auto-dismisses after 3s
* firing `show-pending` twice doesn't stack
* longest error string still wraps fine, no viewport overflow

`tsc` clean, both builds pass.

This is independent of the i18n PR, they just both touch background.ts and contentScript.ts. Happy to rebase whichever one lands second.
